### PR TITLE
Update `syn`

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -14,4 +14,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "1", features = ["full"] }
+syn = { version = "2", features = ["full"] }

--- a/macros/src/track.rs
+++ b/macros/src/track.rs
@@ -69,7 +69,7 @@ enum Kind {
 
 /// Preprocess and validate a method in an impl block.
 fn prepare_impl_method(item: &syn::ImplItem) -> Result<Method> {
-    let syn::ImplItem::Method(method) = item else {
+    let syn::ImplItem::Fn(method) = item else {
         bail!(item, "only methods can be tracked");
     };
 
@@ -78,7 +78,7 @@ fn prepare_impl_method(item: &syn::ImplItem) -> Result<Method> {
 
 /// Preprocess and validate a method in a trait.
 fn prepare_trait_method(item: &syn::TraitItem) -> Result<Method> {
-    let syn::TraitItem::Method(method) = item else {
+    let syn::TraitItem::Fn(method) = item else {
         bail!(item, "only methods can be tracked");
     };
 


### PR DESCRIPTION
Using `cargo tree -d` we can see what versions of dependencies are included multiple times. For `syn` we have

```

syn v1.0.109
├── comemo-macros v0.3.0 (proc-macro)
│   └── comemo v0.3.0
│       ├── typst v0.9.0 (C:\Users\minin\Documents\GitHub\typst\crates\typst) (*)
│       ├── typst-cli v0.9.0 (C:\Users\minin\Documents\GitHub\typst\crates\typst-cli)
│       ├── typst-pdf v0.9.0 (C:\Users\minin\Documents\GitHub\typst\crates\typst-pdf) (*)
│       ├── typst-render v0.9.0 (C:\Users\minin\Documents\GitHub\typst\crates\typst-render) (*)
│       ├── typst-svg v0.9.0 (C:\Users\minin\Documents\GitHub\typst\crates\typst-svg) (*)
│       └── typst-syntax v0.9.0 (C:\Users\minin\Documents\GitHub\typst\crates\typst-syntax)
│           └── typst v0.9.0 (C:\Users\minin\Documents\GitHub\typst\crates\typst) (*)
└── strum_macros v0.24.3 (proc-macro)
    └── strum v0.24.1
        └── biblatex v0.9.0
            └── hayagriva v0.5.0 (*)

syn v2.0.38
[redacted]
```

This means, if we upgrade `syn` in `comemo`, `biblatex`/`hayagriva`, then we'd only have one `syn` version in typst.

I've updated the version, and then ran tests on `typst` with this PR on it, and all tests pass.

I'll see if updating the other dependencies is as easy as that..