### PR TITLE
Parallel comemo & optimizations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,5 +7,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo build
-      - run: cargo test
+      - run: cargo build --all-features
+      - run: cargo test --all-features

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
 .DS_Store
 /target
+macros/target
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ last_was_hit = []
 comemo-macros = { version = "0.3.1", path = "macros" }
 hashbrown = "0.14.3"
 once_cell = "1.18.0"
+parking_lot = "0.12.1"
 siphasher = "1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,11 @@ categories = ["caching"]
 keywords = ["incremental", "memoization", "tracked", "constraints"]
 
 [features]
-default = [ "last_was_hit" ]
+default = [ ]
 last_was_hit = []
 
 [dependencies]
 comemo-macros = { version = "0.3.1", path = "macros" }
-hashbrown = "0.14.3"
 once_cell = "1.18.0"
 parking_lot = "0.12.1"
 siphasher = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,19 @@ categories = ["caching"]
 keywords = ["incremental", "memoization", "tracked", "constraints"]
 
 [features]
-default = [ ]
-last_was_hit = []
+default = []
+testing = []
 
 [dependencies]
 comemo-macros = { version = "0.3.1", path = "macros" }
-once_cell = "1.18.0"
-parking_lot = "0.12.1"
+once_cell = "1.18"
+parking_lot = "0.12"
 siphasher = "1"
 
 [dev-dependencies]
 serial_test = "2.0.0"
+
+[[test]]
+name = "tests"
+path = "tests/tests.rs"
+required-features = ["testing"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ comemo-macros = { version = "0.3.1", path = "macros" }
 hashbrown = "0.14.3"
 once_cell = "1.18.0"
 siphasher = "1"
+
+[dev-dependencies]
+serial_test = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,7 @@ keywords = ["incremental", "memoization", "tracked", "constraints"]
 
 [dependencies]
 comemo-macros = { version = "0.3.1", path = "macros" }
+indexmap = "2.1.0"
+once_cell = "1.18.0"
+rustc-hash = "1.1.0"
 siphasher = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,12 @@ license = "MIT OR Apache-2.0"
 categories = ["caching"]
 keywords = ["incremental", "memoization", "tracked", "constraints"]
 
+[features]
+default = [ "last_was_hit" ]
+last_was_hit = []
+
 [dependencies]
 comemo-macros = { version = "0.3.1", path = "macros" }
-indexmap = "2.1.0"
+hashbrown = "0.14.3"
 once_cell = "1.18.0"
-rustc-hash = "1.1.0"
 siphasher = "1"

--- a/examples/calc.rs
+++ b/examples/calc.rs
@@ -16,33 +16,33 @@ fn main() {
     files.write("gamma.calc", "8 + 3");
 
     // [Miss] The cache is empty.
-    assert_eq!(evaluate("eval alpha.calc", files.track()), 7);
+    assert_eq!(evaluate("eval alpha.calc", &files.track()), 7);
 
     // [Miss] This is not a top-level hit because this exact string was never
     // passed to `evaluate`, but this does not compute "2 + 3" again.
-    assert_eq!(evaluate("eval beta.calc", files.track()), 5);
+    assert_eq!(evaluate("eval beta.calc", &files.track()), 5);
 
     // Modify the gamma file.
     files.write("gamma.calc", "42");
 
     // [Hit] This is a hit because `gamma.calc` isn't referenced by `alpha.calc`.
-    assert_eq!(evaluate("eval alpha.calc", files.track()), 7);
+    assert_eq!(evaluate("eval alpha.calc", &files.track()), 7);
 
     // Modify the beta file.
     files.write("beta.calc", "4 + eval gamma.calc");
 
     // [Miss] This is a miss because `beta.calc` changed.
-    assert_eq!(evaluate("eval alpha.calc", files.track()), 48);
+    assert_eq!(evaluate("eval alpha.calc", &files.track()), 48);
 }
 
 /// Evaluate a `.calc` script.
 #[memoize]
-fn evaluate(script: &str, files: Tracked<Files>) -> i32 {
+fn evaluate(script: &str, files: &Tracked<Files>) -> i32 {
     script
         .split('+')
         .map(str::trim)
         .map(|part| match part.strip_prefix("eval ") {
-            Some(path) => evaluate(&files.read(path), files),
+            Some(path) => evaluate(&files.read(path), &files),
             None => part.parse::<i32>().unwrap(),
         })
         .sum()

--- a/examples/calc.rs
+++ b/examples/calc.rs
@@ -16,33 +16,33 @@ fn main() {
     files.write("gamma.calc", "8 + 3");
 
     // [Miss] The cache is empty.
-    assert_eq!(evaluate("eval alpha.calc", &files.track()), 7);
+    assert_eq!(evaluate("eval alpha.calc", files.track()), 7);
 
     // [Miss] This is not a top-level hit because this exact string was never
     // passed to `evaluate`, but this does not compute "2 + 3" again.
-    assert_eq!(evaluate("eval beta.calc", &files.track()), 5);
+    assert_eq!(evaluate("eval beta.calc", files.track()), 5);
 
     // Modify the gamma file.
     files.write("gamma.calc", "42");
 
     // [Hit] This is a hit because `gamma.calc` isn't referenced by `alpha.calc`.
-    assert_eq!(evaluate("eval alpha.calc", &files.track()), 7);
+    assert_eq!(evaluate("eval alpha.calc", files.track()), 7);
 
     // Modify the beta file.
     files.write("beta.calc", "4 + eval gamma.calc");
 
     // [Miss] This is a miss because `beta.calc` changed.
-    assert_eq!(evaluate("eval alpha.calc", &files.track()), 48);
+    assert_eq!(evaluate("eval alpha.calc", files.track()), 48);
 }
 
 /// Evaluate a `.calc` script.
 #[memoize]
-fn evaluate(script: &str, files: &Tracked<Files>) -> i32 {
+fn evaluate(script: &str, files: Tracked<Files>) -> i32 {
     script
         .split('+')
         .map(str::trim)
         .map(|part| match part.strip_prefix("eval ") {
-            Some(path) => evaluate(&files.read(path), &files),
+            Some(path) => evaluate(&files.read(path), files),
             None => part.parse::<i32>().unwrap(),
         })
         .sum()

--- a/macros/src/memoize.rs
+++ b/macros/src/memoize.rs
@@ -129,13 +129,9 @@ fn process(function: &Function) -> Result<TokenStream> {
             <::comemo::internal::Args<#arg_ty_tuple> as ::comemo::internal::Input>::Constraint,
             #output,
         > = ::comemo::internal::Cache::new(|| {
-            ::comemo::internal::register_cache(evict);
-            ::comemo::internal::RwLock::new(::comemo::internal::CacheData::new())
+            ::comemo::internal::register_evictor(|max_age| __CACHE.evict(max_age));
+            ::std::default::Default::default()
         });
-
-        fn evict(max_age: usize) {
-            __CACHE.write().evict(max_age);
-        }
 
         #(#bounds;)*
         ::comemo::internal::memoized(

--- a/macros/src/memoize.rs
+++ b/macros/src/memoize.rs
@@ -124,7 +124,6 @@ fn process(function: &Function) -> Result<TokenStream> {
         ident.mutability = None;
     }
 
-    let unique = quote! { __ComemoUnique };
     wrapped.block = parse_quote! { {
         static __CACHE: ::comemo::internal::Lazy<
             ::std::sync::RwLock<
@@ -145,7 +144,6 @@ fn process(function: &Function) -> Result<TokenStream> {
             __CACHE.write().unwrap().evict(max_age);
         }
 
-        struct #unique;
         #(#bounds;)*
         ::comemo::internal::memoized(
             ::comemo::internal::Args(#arg_tuple),

--- a/macros/src/memoize.rs
+++ b/macros/src/memoize.rs
@@ -130,7 +130,7 @@ fn process(function: &Function) -> Result<TokenStream> {
             #output,
         > = ::comemo::internal::Cache::new(|| {
             ::comemo::internal::register_evictor(|max_age| __CACHE.evict(max_age));
-            ::std::default::Default::default()
+            ::core::default::Default::default()
         });
 
         #(#bounds;)*

--- a/macros/src/memoize.rs
+++ b/macros/src/memoize.rs
@@ -126,7 +126,7 @@ fn process(function: &Function) -> Result<TokenStream> {
 
     wrapped.block = parse_quote! { {
         static __CACHE: ::comemo::internal::Lazy<
-            ::std::sync::RwLock<
+            ::comemo::internal::RwLock<
                 ::comemo::internal::Cache<
                     <::comemo::internal::Args<#arg_ty_tuple> as ::comemo::internal::Input>::Constraint,
                     #output,
@@ -136,12 +136,12 @@ fn process(function: &Function) -> Result<TokenStream> {
             ::comemo::internal::Lazy::new(
                 || {
                     ::comemo::internal::register_cache(evict);
-                    ::std::sync::RwLock::new(::comemo::internal::Cache::new())
+                    ::comemo::internal::RwLock::new(::comemo::internal::Cache::new())
                 }
             );
 
         fn evict(max_age: usize) {
-            __CACHE.write().unwrap().evict(max_age);
+            __CACHE.write().evict(max_age);
         }
 
         #(#bounds;)*

--- a/macros/src/track.rs
+++ b/macros/src/track.rs
@@ -244,11 +244,16 @@ fn create(
         .map(|m| create_wrapper(m, false));
     let wrapper_methods_mut = methods.iter().map(|m| create_wrapper(m, true));
 
+    let constraint = if methods.iter().all(|m| !m.mutable) {
+        quote! { ImmutableConstraint }
+    } else {
+        quote! { Constraint }
+    };
     Ok(quote! {
         impl #impl_params ::comemo::Track for #ty  #where_clause {}
 
         impl #impl_params ::comemo::Validate for #ty  #where_clause {
-            type Constraint = ::comemo::internal::Constraint<__ComemoCall>;
+            type Constraint = ::comemo::internal::#constraint<__ComemoCall>;
 
             #[inline]
             fn validate(&self, constraint: &Self::Constraint) -> bool {

--- a/macros/src/track.rs
+++ b/macros/src/track.rs
@@ -36,7 +36,7 @@ pub fn expand(item: &syn::Item) -> Result<TokenStream> {
             }
 
             let name = &item.ident;
-            let ty = parse_quote! { dyn #name + '__comemo_dynamic };
+            let ty = parse_quote! { dyn #name + Send + Sync + '__comemo_dynamic };
             (ty, &item.generics, Some(name.clone()))
         }
         _ => bail!(item, "`track` can only be applied to impl blocks and traits"),

--- a/macros/src/track.rs
+++ b/macros/src/track.rs
@@ -229,8 +229,9 @@ fn create(
     };
 
     // Prepare replying.
+    let immutable = methods.iter().all(|m| !m.mutable);
     let replays = methods.iter().map(create_replay);
-    let replay = methods.iter().any(|m| m.mutable).then(|| {
+    let replay = (!immutable).then(|| {
         quote! {
             constraint.replay(|call| match &call.0 { #(#replays,)* });
         }

--- a/macros/src/track.rs
+++ b/macros/src/track.rs
@@ -219,9 +219,9 @@ fn create(
     let validate_with_id = if !methods.is_empty() {
         quote! {
             let mut this = #maybe_cloned;
-            constraint.validate_with_id(
+            constraint.validate_with_accelerator(
                 |call| match &call.0 { #(#validations,)* },
-                id,
+                accelerator,
             )
         }
     } else {
@@ -262,7 +262,7 @@ fn create(
             }
 
             #[inline]
-            fn validate_with_id(&self, constraint: &Self::Constraint, id: usize) -> bool {
+            fn validate_with_accelerator(&self, constraint: &Self::Constraint, accelerator: &::comemo::internal::Accelerator) -> bool {
                 #validate_with_id
             }
 
@@ -378,7 +378,7 @@ fn create_wrapper(method: &Method, tracked_mut: bool) -> TokenStream {
     let args = &method.args;
     let mutable = method.mutable;
     let to_parts = if !tracked_mut {
-        quote! { to_parts_ref(self.0) }
+        quote! { to_parts_ref(&self.0) }
     } else if !mutable {
         quote! { to_parts_mut_ref(&self.0) }
     } else {

--- a/macros/src/track.rs
+++ b/macros/src/track.rs
@@ -213,7 +213,6 @@ fn create_variants(methods: &[Method]) -> TokenStream {
         enum __ComemoVariant {
             #(#variants,)*
         }
-
     }
 }
 
@@ -291,6 +290,7 @@ fn create(
     } else {
         quote! { MutableConstraint }
     };
+
     Ok(quote! {
         impl #impl_params ::comemo::Track for #ty #where_clause {}
 

--- a/macros/src/track.rs
+++ b/macros/src/track.rs
@@ -219,9 +219,9 @@ fn create(
     let validate_with_id = if !methods.is_empty() {
         quote! {
             let mut this = #maybe_cloned;
-            constraint.validate_with_accelerator(
+            constraint.validate_with_id(
                 |call| match &call.0 { #(#validations,)* },
-                accelerator,
+                id,
             )
         }
     } else {
@@ -262,7 +262,7 @@ fn create(
             }
 
             #[inline]
-            fn validate_with_accelerator(&self, constraint: &Self::Constraint, accelerator: &::comemo::internal::Accelerator) -> bool {
+            fn validate_with_id(&self, constraint: &Self::Constraint, id: usize) -> bool {
                 #validate_with_id
             }
 

--- a/src/accelerate.rs
+++ b/src/accelerate.rs
@@ -1,0 +1,63 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use parking_lot::{MappedRwLockReadGuard, Mutex, RwLock, RwLockReadGuard};
+
+/// The global list of currently alive accelerators.
+static ACCELERATORS: RwLock<(usize, Vec<Accelerator>)> = RwLock::new((0, Vec::new()));
+
+/// The current ID of the accelerator.
+static ID: AtomicUsize = AtomicUsize::new(0);
+
+/// The type of each individual accelerator.
+///
+/// Maps from call hashes to return hashes.
+type Accelerator = Mutex<HashMap<u128, u128>>;
+
+/// Generate a new accelerator.
+pub fn id() -> usize {
+    // Get the next ID.
+    ID.fetch_add(1, Ordering::SeqCst)
+}
+
+/// Evict the accelerators.
+pub fn evict() {
+    let mut accelerators = ACCELERATORS.write();
+    let (offset, vec) = &mut *accelerators;
+
+    // Update the offset.
+    *offset = ID.load(Ordering::SeqCst);
+
+    // Clear all accelerators while keeping the memory allocated.
+    vec.iter_mut().for_each(|accelerator| accelerator.lock().clear())
+}
+
+/// Get an accelerator by ID.
+pub fn get(id: usize) -> Option<MappedRwLockReadGuard<'static, Accelerator>> {
+    // We always lock the accelerators, as we need to make sure that the
+    // accelerator is not removed while we are reading it.
+    let mut accelerators = ACCELERATORS.read();
+
+    let mut i = id.checked_sub(accelerators.0)?;
+    if i >= accelerators.1.len() {
+        drop(accelerators);
+        resize(i + 1);
+        accelerators = ACCELERATORS.read();
+
+        // Because we release the lock before resizing the accelerator, we need
+        // to check again whether the ID is still valid because another thread
+        // might evicted the cache.
+        i = id.checked_sub(accelerators.0)?;
+    }
+
+    Some(RwLockReadGuard::map(accelerators, move |(_, vec)| &vec[i]))
+}
+
+/// Adjusts the amount of accelerators.
+#[cold]
+fn resize(len: usize) {
+    let mut pair = ACCELERATORS.write();
+    if len > pair.1.len() {
+        pair.1.resize_with(len, || Mutex::new(HashMap::new()));
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::cell::Cell;
 use std::collections::HashMap;
-use std::hash::{Hash, BuildHasherDefault};
+use std::hash::{BuildHasherDefault, Hash};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Mutex, RwLock};
 
@@ -273,7 +273,10 @@ impl<T: Hash + PartialEq + Clone> Constraint<T> {
     #[inline]
     pub fn push(&self, args: T, ret: u128, mutable: bool) {
         let both = hash(&(&args, ret));
-        self.0.write().unwrap().push_inner(Cow::Owned(Call { args, ret, both, mutable }));
+        self.0
+            .write()
+            .unwrap()
+            .push_inner(Cow::Owned(Call { args, ret, both, mutable }));
     }
 
     /// Whether the method satisfies as all input-output pairs.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -25,9 +25,7 @@ pub fn register_cache(fun: fn(usize)) {
 }
 
 /// Generate a new accelerator.
-/// 
-/// Will allocate a new accelerator if the ID is larger than the current
-/// capacity.
+/// Will allocate a new accelerator if the ID is larger than the current capacity.
 pub fn id() -> usize {
     // Get the next ID.
     ID.fetch_add(1, Ordering::AcqRel)

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -123,10 +123,12 @@ impl<C, Out> Default for Cache<C, Out> {
 }
 
 impl<C, Out: 'static> Cache<C, Out> {
+    /// Create an empty cache.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Evict all entries whose age is larger than or equal to `max_age`.
     pub fn evict(&mut self, max_age: usize) {
         self.entries.retain(|_, entries| {
             entries.retain_mut(|entry| {
@@ -206,7 +208,13 @@ struct Call<T> {
 pub struct Constraint<T>(RwLock<Inner<T>>);
 
 struct Inner<T> {
+    /// The list of calls.
+    ///
+    /// Order matters here, as those are mutable & immutable calls.
     calls: Vec<Call<T>>,
+    /// The hash of the arguments and index of the call.
+    ///
+    /// Order does not matter here, as those are immutable calls.
     immutable: HashMap<u128, usize>,
 }
 
@@ -236,9 +244,7 @@ impl<T: Hash + PartialEq + Clone> Inner<T> {
                 #[cfg(debug_assertions)]
                 {
                     let prev = &self.calls[*_prev];
-                    if prev.args == call.args {
-                        check(prev.ret, call.ret);
-                    }
+                    check(prev.ret, call.ret);
                 }
 
                 return;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -66,7 +66,7 @@ where
     }
 
     // Release the borrow so that nested memoized calls can access the
-    // cache without panicking.
+    // cache without dead locking.
     drop(borrow);
 
     // Execute the function with the new constraints hooked in.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -3,9 +3,7 @@ use std::sync::atomic::Ordering;
 use std::{borrow::Cow, sync::atomic::AtomicUsize};
 
 use hashbrown::HashMap;
-use parking_lot::{
-    MappedRwLockReadGuard, Mutex, RwLock, RwLockReadGuard,
-};
+use parking_lot::{MappedRwLockReadGuard, Mutex, RwLock, RwLockReadGuard};
 use siphasher::sip128::{Hasher128, SipHasher13};
 
 use crate::input::Input;
@@ -35,9 +33,7 @@ fn offset() -> usize {
 /// Generate a new accelerator.
 pub fn id() -> usize {
     #[cold]
-    fn allocate_accelerator(
-        len: usize,
-    ) {
+    fn allocate_accelerator(len: usize) {
         let mut accelerators = ACCELERATORS.write();
         // If it was grown by another thread, we can just return.
         if accelerators.len() >= len {
@@ -73,10 +69,7 @@ fn accelerator(id: usize) -> Option<MappedRwLockReadGuard<'static, Accelerator>>
     }
 
     let i = id - offset;
-    Some(RwLockReadGuard::map(
-        accelerators,
-        move |accelerators| &accelerators[i],
-    ))
+    Some(RwLockReadGuard::map(accelerators, move |accelerators| &accelerators[i]))
 }
 
 #[cfg(feature = "last_was_hit")]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -207,6 +207,7 @@ struct Call<T> {
 /// Defines a constraint for a tracked type.
 pub struct Constraint<T>(RwLock<Inner<T>>);
 
+#[derive(Clone)]
 struct Inner<T> {
     /// The list of calls.
     ///
@@ -221,15 +222,6 @@ struct Inner<T> {
 impl<T: Clone> Clone for Constraint<T> {
     fn clone(&self) -> Self {
         Self(RwLock::new(self.0.read().unwrap().clone()))
-    }
-}
-
-impl<T: Clone> Clone for Inner<T> {
-    fn clone(&self) -> Self {
-        Self {
-            calls: self.calls.clone(),
-            immutable: self.immutable.clone(),
-        }
     }
 }
 
@@ -418,7 +410,7 @@ impl<T: Clone> Clone for ImmutableConstraint<T> {
 
 impl<T> Default for ImmutableConstraint<T> {
     fn default() -> Self {
-        Self(RwLock::new(HashMap::with_hasher(Default::default())))
+        Self(RwLock::new(HashMap::default()))
     }
 }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,31 +1,41 @@
-use std::any::{Any, TypeId};
-use std::cell::{Cell, RefCell};
+use std::borrow::Cow;
+use std::cell::Cell;
 use std::collections::HashMap;
-use std::hash::Hash;
+use std::hash::{Hash, BuildHasherDefault};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Mutex, RwLock};
 
+use once_cell::sync::Lazy;
+use rustc_hash::{FxHashMap, FxHasher};
 use siphasher::sip128::{Hasher128, SipHasher13};
 
 use crate::input::Input;
 
-thread_local! {
-    /// The global, dynamic cache shared by all memoized functions.
-    static CACHE: RefCell<Cache> = RefCell::new(Cache::default());
+type FxIndexMap<K, V> = indexmap::IndexMap<K, V, BuildHasherDefault<FxHasher>>;
 
-    /// The global ID counter for tracked values. Each tracked value gets a
-    /// unqiue ID based on which its validations are cached in the accelerator.
-    /// IDs may only be reused upon eviction of the accelerator.
-    static ID: Cell<usize> = const { Cell::new(0) };
+static CACHES: RwLock<Vec<fn(usize)>> = RwLock::new(Vec::new());
 
-    /// The global, dynamic accelerator shared by all cached values.
-    static ACCELERATOR: RefCell<HashMap<(usize, u128), u128>>
-        = RefCell::new(HashMap::default());
+static ACCELERATOR: Lazy<Mutex<FxHashMap<(usize, u128), u128>>> =
+    Lazy::new(|| Mutex::new(FxHashMap::default()));
+
+pub fn register_cache(fun: fn(usize)) {
+    CACHES.write().unwrap().push(fun);
 }
+
+thread_local! {
+    static LAST_WAS_HIT: Cell<bool> = const { Cell::new(false) };
+}
+
+/// The global ID counter for tracked values. Each tracked value gets a
+/// unqiue ID based on which its validations are cached in the accelerator.
+/// IDs may only be reused upon eviction of the accelerator.
+static ID: AtomicUsize = AtomicUsize::new(0);
 
 /// Execute a function or use a cached result for it.
 pub fn memoized<'c, In, Out, F>(
-    id: TypeId,
     mut input: In,
     constraint: &'c In::Constraint,
+    cache: &RwLock<Cache<In::Constraint, Out>>,
     func: F,
 ) -> Out
 where
@@ -33,61 +43,54 @@ where
     Out: Clone + 'static,
     F: FnOnce(In::Tracked<'c>) -> Out,
 {
-    CACHE.with(|cache| {
-        // Compute the hash of the input's key part.
-        let key = {
-            let mut state = SipHasher13::new();
-            input.key(&mut state);
-            let hash = state.finish128().as_u128();
-            (id, hash)
-        };
+    // Compute the hash of the input's key part.
+    let key = {
+        let mut state = SipHasher13::new();
+        input.key(&mut state);
+        state.finish128().as_u128()
+    };
 
-        // Check if there is a cached output.
-        let mut borrow = cache.borrow_mut();
-        if let Some(constrained) = borrow.lookup::<In, Out>(key, &input) {
-            // Replay the mutations.
-            input.replay(&constrained.constraint);
+    // Check if there is a cached output.
+    let mut borrow = cache.write().unwrap();
+    if let Some(constrained) = borrow.lookup::<In>(key, &input) {
+        // Replay the mutations.
+        input.replay(&constrained.constraint);
 
-            // Add the cached constraints to the outer ones.
-            input.retrack(constraint).1.join(&constrained.constraint);
+        // Add the cached constraints to the outer ones.
+        input.retrack(constraint).1.join(&constrained.constraint);
 
-            let value = constrained.output.clone();
-            borrow.last_was_hit = true;
-            return value;
-        }
+        let value = constrained.output.clone();
+        LAST_WAS_HIT.with(|cell| cell.set(true));
+        return value;
+    }
 
-        // Release the borrow so that nested memoized calls can access the
-        // cache without panicking.
-        drop(borrow);
+    // Release the borrow so that nested memoized calls can access the
+    // cache without panicking.
+    drop(borrow);
 
-        // Execute the function with the new constraints hooked in.
-        let (input, outer) = input.retrack(constraint);
-        let output = func(input);
+    // Execute the function with the new constraints hooked in.
+    let (input, outer) = input.retrack(constraint);
+    let output = func(input);
 
-        // Add the new constraints to the outer ones.
-        outer.join(constraint);
+    // Add the new constraints to the outer ones.
+    outer.join(constraint);
 
-        // Insert the result into the cache.
-        borrow = cache.borrow_mut();
-        borrow.insert::<In, Out>(key, constraint.take(), output.clone());
-        borrow.last_was_hit = false;
+    // Insert the result into the cache.
+    borrow = cache.write().unwrap();
+    borrow.insert::<In>(key, constraint.take(), output.clone());
+    LAST_WAS_HIT.with(|cell| cell.set(false));
 
-        output
-    })
+    output
 }
 
 /// Whether the last call was a hit.
 pub fn last_was_hit() -> bool {
-    CACHE.with(|cache| cache.borrow().last_was_hit)
+    LAST_WAS_HIT.with(|cell| cell.get())
 }
 
 /// Get the next ID.
 pub fn id() -> usize {
-    ID.with(|cell| {
-        let current = cell.get();
-        cell.set(current.wrapping_add(1));
-        current
-    })
+    ID.fetch_add(1, Ordering::SeqCst)
 }
 
 /// Evict the cache.
@@ -100,69 +103,71 @@ pub fn id() -> usize {
 /// Comemo's cache is thread-local, meaning that this only evicts this thread's
 /// cache.
 pub fn evict(max_age: usize) {
-    CACHE.with(|cache| {
-        let mut cache = cache.borrow_mut();
-        cache.map.retain(|_, entries| {
+    CACHES.read().unwrap().iter().for_each(|fun| fun(max_age));
+    ACCELERATOR.lock().unwrap().clear();
+}
+
+/// The global cache.
+pub struct Cache<C, Out> {
+    /// Maps from hashes to memoized results.
+    entries: HashMap<u128, Vec<CacheEntry<C, Out>>>,
+}
+
+impl<C, Out> Default for Cache<C, Out> {
+    fn default() -> Self {
+        Self { entries: HashMap::new() }
+    }
+}
+
+impl<C, Out: 'static> Cache<C, Out> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn evict(&mut self, max_age: usize) {
+        self.entries.retain(|_, entries| {
             entries.retain_mut(|entry| {
                 entry.age += 1;
                 entry.age <= max_age
             });
             !entries.is_empty()
         });
-    });
-    ACCELERATOR.with(|accelerator| accelerator.borrow_mut().clear());
-}
+    }
 
-/// The global cache.
-#[derive(Default)]
-struct Cache {
-    /// Maps from function IDs + hashes to memoized results.
-    map: HashMap<(TypeId, u128), Vec<CacheEntry>>,
-    /// Whether the last call was a hit.
-    last_was_hit: bool,
-}
-
-impl Cache {
     /// Look for a matching entry in the cache.
-    fn lookup<In, Out>(
+    fn lookup<In>(
         &mut self,
-        key: (TypeId, u128),
+        key: u128,
         input: &In,
     ) -> Option<&Constrained<In::Constraint, Out>>
     where
-        In: Input,
-        Out: Clone + 'static,
+        In: Input<Constraint = C>,
     {
-        self.map
+        self.entries
             .get_mut(&key)?
             .iter_mut()
             .rev()
-            .find_map(|entry| entry.lookup::<In, Out>(input))
+            .find_map(|entry| entry.lookup::<In>(input))
     }
 
     /// Insert an entry into the cache.
-    fn insert<In, Out>(
-        &mut self,
-        key: (TypeId, u128),
-        constraint: In::Constraint,
-        output: Out,
-    ) where
-        In: Input,
-        Out: 'static,
+    fn insert<In>(&mut self, key: u128, constraint: In::Constraint, output: Out)
+    where
+        In: Input<Constraint = C>,
     {
-        self.map
+        self.entries
             .entry(key)
             .or_default()
-            .push(CacheEntry::new::<In, Out>(constraint, output));
+            .push(CacheEntry::new::<In>(constraint, output));
     }
 }
 
 /// A memoized result.
-struct CacheEntry {
+struct CacheEntry<C, Out> {
     /// The memoized function's constrained output.
     ///
     /// This is of type `Constrained<In::Constraint, Out>`.
-    constrained: Box<dyn Any>,
+    constrained: Constrained<C, Out>,
     /// How many evictions have passed since the entry has been last used.
     age: usize,
 }
@@ -175,38 +180,52 @@ struct Constrained<C, T> {
     output: T,
 }
 
-impl CacheEntry {
+impl<C, Out: 'static> CacheEntry<C, Out> {
     /// Create a new entry.
-    fn new<In, Out>(constraint: In::Constraint, output: Out) -> Self
+    fn new<In>(constraint: In::Constraint, output: Out) -> Self
     where
-        In: Input,
-        Out: 'static,
+        In: Input<Constraint = C>,
     {
         Self {
-            constrained: Box::new(Constrained { constraint, output }),
+            constrained: Constrained { constraint, output },
             age: 0,
         }
     }
 
     /// Return the entry's output if it is valid for the given input.
-    fn lookup<In, Out>(&mut self, input: &In) -> Option<&Constrained<In::Constraint, Out>>
+    fn lookup<In>(&mut self, input: &In) -> Option<&Constrained<In::Constraint, Out>>
     where
-        In: Input,
-        Out: Clone + 'static,
+        In: Input<Constraint = C>,
     {
-        let constrained: &Constrained<In::Constraint, Out> =
-            self.constrained.downcast_ref().expect("wrong entry type");
-
-        input.validate(&constrained.constraint).then(|| {
+        input.validate(&self.constrained.constraint).then(|| {
             self.age = 0;
-            constrained
+            &self.constrained
         })
     }
 }
 
 /// Defines a constraint for a tracked type.
-#[derive(Clone)]
-pub struct Constraint<T>(RefCell<Vec<Call<T>>>);
+pub struct Constraint<T>(RwLock<Inner<T>>);
+
+struct Inner<T> {
+    calls: Vec<Call<T>>,
+    immutable: FxHashMap<u128, usize>,
+}
+
+impl<T: Clone> Clone for Constraint<T> {
+    fn clone(&self) -> Self {
+        Self(RwLock::new(self.0.read().unwrap().clone()))
+    }
+}
+
+impl<T: Clone> Clone for Inner<T> {
+    fn clone(&self) -> Self {
+        Self {
+            calls: self.calls.clone(),
+            immutable: self.immutable.clone(),
+        }
+    }
+}
 
 /// A call entry.
 #[derive(Clone)]
@@ -217,7 +236,34 @@ struct Call<T> {
     mutable: bool,
 }
 
-impl<T: Hash + PartialEq> Constraint<T> {
+impl<T: Hash + PartialEq + Clone> Inner<T> {
+    /// Enter a constraint for a call to an immutable function.
+    #[inline]
+    fn push_inner(&mut self, call: Cow<Call<T>>) {
+        if !call.mutable {
+            if let Some(_prev) = self.immutable.get(&call.both) {
+                #[cfg(debug_assertions)]
+                {
+                    let prev = &self.calls[*_prev];
+                    if prev.args == call.args {
+                        check(prev.ret, call.ret);
+                    }
+                }
+
+                return;
+            }
+        }
+
+        if call.mutable {
+            self.immutable.clear();
+        } else {
+            self.immutable.insert(call.both, self.calls.len());
+        }
+        self.calls.push(call.into_owned());
+    }
+}
+
+impl<T: Hash + PartialEq + Clone> Constraint<T> {
     /// Create empty constraints.
     pub fn new() -> Self {
         Self::default()
@@ -227,32 +273,7 @@ impl<T: Hash + PartialEq> Constraint<T> {
     #[inline]
     pub fn push(&self, args: T, ret: u128, mutable: bool) {
         let both = hash(&(&args, ret));
-        self.push_inner(Call { args, ret, both, mutable });
-    }
-
-    /// Enter a constraint for a call to an immutable function.
-    #[inline]
-    fn push_inner(&self, call: Call<T>) {
-        let mut calls = self.0.borrow_mut();
-
-        if !call.mutable {
-            for prev in calls.iter().rev() {
-                if prev.mutable {
-                    break;
-                }
-
-                #[cfg(debug_assertions)]
-                if prev.args == call.args {
-                    check(prev.ret, call.ret);
-                }
-
-                if prev.both == call.both {
-                    return;
-                }
-            }
-        }
-
-        calls.push(call);
+        self.0.write().unwrap().push_inner(Cow::Owned(Call { args, ret, both, mutable }));
     }
 
     /// Whether the method satisfies as all input-output pairs.
@@ -261,7 +282,12 @@ impl<T: Hash + PartialEq> Constraint<T> {
     where
         F: FnMut(&T) -> u128,
     {
-        self.0.borrow().iter().all(|entry| f(&entry.args) == entry.ret)
+        self.0
+            .read()
+            .unwrap()
+            .calls
+            .iter()
+            .all(|entry| f(&entry.args) == entry.ret)
     }
 
     /// Whether the method satisfies as all input-output pairs.
@@ -270,13 +296,10 @@ impl<T: Hash + PartialEq> Constraint<T> {
     where
         F: FnMut(&T) -> u128,
     {
-        let calls = self.0.borrow();
-        ACCELERATOR.with(|accelerator| {
-            let mut map = accelerator.borrow_mut();
-            calls.iter().all(|entry| {
-                *map.entry((id, entry.both)).or_insert_with(|| f(&entry.args))
-                    == entry.ret
-            })
+        let inner = self.0.read().unwrap();
+        let mut map = ACCELERATOR.lock().unwrap();
+        inner.calls.iter().all(|entry| {
+            *map.entry((id, entry.both)).or_insert_with(|| f(&entry.args)) == entry.ret
         })
     }
 
@@ -286,7 +309,7 @@ impl<T: Hash + PartialEq> Constraint<T> {
     where
         F: FnMut(&T),
     {
-        for entry in self.0.borrow().iter() {
+        for entry in self.0.read().unwrap().calls.iter() {
             if entry.mutable {
                 f(&entry.args);
             }
@@ -296,7 +319,97 @@ impl<T: Hash + PartialEq> Constraint<T> {
 
 impl<T> Default for Constraint<T> {
     fn default() -> Self {
-        Self(RefCell::new(vec![]))
+        Self(RwLock::new(Inner { calls: Vec::new(), immutable: FxHashMap::default() }))
+    }
+}
+
+impl<T> Default for Inner<T> {
+    fn default() -> Self {
+        Self { calls: Vec::new(), immutable: FxHashMap::default() }
+    }
+}
+
+/// Defines a constraint for a tracked type.
+pub struct ImmutableConstraint<T>(RwLock<FxIndexMap<u128, Call<T>>>);
+
+impl<T: Clone> Clone for ImmutableConstraint<T> {
+    fn clone(&self) -> Self {
+        Self(RwLock::new(self.0.read().unwrap().clone()))
+    }
+}
+
+impl<T: Hash + PartialEq + Clone> ImmutableConstraint<T> {
+    /// Create empty constraints.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Enter a constraint for a call to an immutable function.
+    #[inline]
+    pub fn push(&self, args: T, ret: u128, mutable: bool) {
+        let both = hash(&(&args, ret));
+        self.push_inner(Cow::Owned(Call { args, ret, both, mutable }));
+    }
+
+    /// Enter a constraint for a call to an immutable function.
+    #[inline]
+    fn push_inner(&self, call: Cow<Call<T>>) {
+        let mut calls = self.0.write().unwrap();
+        debug_assert!(!call.mutable);
+
+        if let Some(_prev) = calls.get(&call.both) {
+            #[cfg(debug_assertions)]
+            if _prev.args == call.args {
+                check(_prev.ret, call.ret);
+            }
+
+            return;
+        }
+
+        calls.insert(call.both, call.into_owned());
+    }
+
+    /// Whether the method satisfies as all input-output pairs.
+    #[inline]
+    pub fn validate<F>(&self, mut f: F) -> bool
+    where
+        F: FnMut(&T) -> u128,
+    {
+        self.0
+            .read()
+            .unwrap()
+            .values()
+            .all(|entry| f(&entry.args) == entry.ret)
+    }
+
+    /// Whether the method satisfies as all input-output pairs.
+    #[inline]
+    pub fn validate_with_id<F>(&self, mut f: F, id: usize) -> bool
+    where
+        F: FnMut(&T) -> u128,
+    {
+        let calls = self.0.read().unwrap();
+        let mut map = ACCELERATOR.lock().unwrap();
+        calls.values().all(|entry| {
+            *map.entry((id, entry.both)).or_insert_with(|| f(&entry.args)) == entry.ret
+        })
+    }
+
+    /// Replay all input-output pairs.
+    #[inline]
+    pub fn replay<F>(&self, _: F)
+    where
+        F: FnMut(&T),
+    {
+        for entry in self.0.read().unwrap().values() {
+            debug_assert!(!entry.mutable);
+        }
+    }
+}
+
+impl<T> Default for ImmutableConstraint<T> {
+    fn default() -> Self {
+        Self(RwLock::new(FxIndexMap::with_hasher(Default::default())))
     }
 }
 
@@ -326,14 +439,29 @@ impl<T: Join> Join<T> for Option<&T> {
 impl<T: Hash + Clone + PartialEq> Join for Constraint<T> {
     #[inline]
     fn join(&self, inner: &Self) {
-        for call in inner.0.borrow().iter() {
-            self.push_inner(call.clone());
+        let mut this = self.0.write().unwrap();
+        for call in inner.0.read().unwrap().calls.iter() {
+            this.push_inner(Cow::Borrowed(call));
         }
     }
 
     #[inline]
     fn take(&self) -> Self {
-        Self(RefCell::new(std::mem::take(&mut *self.0.borrow_mut())))
+        Self(RwLock::new(std::mem::take(&mut *self.0.write().unwrap())))
+    }
+}
+
+impl<T: Hash + Clone + PartialEq> Join for ImmutableConstraint<T> {
+    #[inline]
+    fn join(&self, inner: &Self) {
+        for call in inner.0.read().unwrap().values() {
+            self.push_inner(Cow::Borrowed(call));
+        }
+    }
+
+    #[inline]
+    fn take(&self) -> Self {
+        Self(RwLock::new(std::mem::take(&mut *self.0.write().unwrap())))
     }
 }
 

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -1,0 +1,301 @@
+use std::borrow::Cow;
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::hash::Hash;
+
+use parking_lot::RwLock;
+use siphasher::sip128::{Hasher128, SipHasher13};
+
+use crate::accelerate;
+
+/// A call to a tracked function.
+pub trait Call: Hash + PartialEq + Clone {
+    /// Whether the call is mutable.
+    fn is_mutable(&self) -> bool;
+}
+
+/// A constraint entry for a single call.
+#[derive(Clone)]
+struct ConstraintEntry<T: Call> {
+    call: T,
+    call_hash: u128,
+    ret_hash: u128,
+}
+
+/// Defines a constraint for an immutably tracked type.
+pub struct ImmutableConstraint<T: Call>(RwLock<EntryMap<T>>);
+
+impl<T: Call> ImmutableConstraint<T> {
+    /// Create an empty constraint.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Enter a constraint for a call to an immutable function.
+    #[inline]
+    pub fn push(&self, call: T, ret_hash: u128) {
+        let call_hash = hash(&call);
+        let entry = ConstraintEntry { call, call_hash, ret_hash };
+        self.0.write().push_inner(Cow::Owned(entry));
+    }
+
+    /// Whether the method satisfies as all input-output pairs.
+    #[inline]
+    pub fn validate<F>(&self, mut f: F) -> bool
+    where
+        F: FnMut(&T) -> u128,
+    {
+        self.0.read().0.values().all(|entry| f(&entry.call) == entry.ret_hash)
+    }
+
+    /// Whether the method satisfies as all input-output pairs.
+    #[inline]
+    pub fn validate_with_id<F>(&self, mut f: F, id: usize) -> bool
+    where
+        F: FnMut(&T) -> u128,
+    {
+        let guard = self.0.read();
+        if let Some(accelerator) = accelerate::get(id) {
+            let mut map = accelerator.lock();
+            guard.0.values().all(|entry| {
+                *map.entry(entry.call_hash).or_insert_with(|| f(&entry.call))
+                    == entry.ret_hash
+            })
+        } else {
+            guard.0.values().all(|entry| f(&entry.call) == entry.ret_hash)
+        }
+    }
+
+    /// Replay all input-output pairs.
+    #[inline]
+    pub fn replay<F>(&self, _: F)
+    where
+        F: FnMut(&T),
+    {
+        #[cfg(debug_assertions)]
+        for entry in self.0.read().0.values() {
+            assert!(!entry.call.is_mutable());
+        }
+    }
+}
+
+impl<T: Call> Clone for ImmutableConstraint<T> {
+    fn clone(&self) -> Self {
+        Self(RwLock::new(self.0.read().clone()))
+    }
+}
+
+impl<T: Call> Default for ImmutableConstraint<T> {
+    fn default() -> Self {
+        Self(RwLock::new(EntryMap::default()))
+    }
+}
+
+/// Defines a constraint for a mutably tracked type.
+pub struct MutableConstraint<T: Call>(RwLock<EntryVec<T>>);
+
+impl<T: Call> MutableConstraint<T> {
+    /// Create an empty constraint.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Enter a constraint for a call to a mutable function.
+    #[inline]
+    pub fn push(&self, call: T, ret_hash: u128) {
+        let call_hash = hash(&call);
+        let entry = ConstraintEntry { call, call_hash, ret_hash };
+        self.0.write().push_inner(Cow::Owned(entry));
+    }
+
+    /// Whether the method satisfies as all input-output pairs.
+    #[inline]
+    pub fn validate<F>(&self, mut f: F) -> bool
+    where
+        F: FnMut(&T) -> u128,
+    {
+        self.0.read().0.iter().all(|entry| f(&entry.call) == entry.ret_hash)
+    }
+
+    /// Whether the method satisfies as all input-output pairs.
+    ///
+    /// On mutable tracked types, this does not use an accelerator as it is
+    /// rarely, if ever used. Therefore, it is not worth the overhead.
+    #[inline]
+    pub fn validate_with_id<F>(&self, f: F, _: usize) -> bool
+    where
+        F: FnMut(&T) -> u128,
+    {
+        self.validate(f)
+    }
+
+    /// Replay all input-output pairs.
+    #[inline]
+    pub fn replay<F>(&self, mut f: F)
+    where
+        F: FnMut(&T),
+    {
+        for call in &self.0.read().0 {
+            if call.call.is_mutable() {
+                f(&call.call);
+            }
+        }
+    }
+}
+
+impl<T: Call> Clone for MutableConstraint<T> {
+    fn clone(&self) -> Self {
+        Self(RwLock::new(self.0.read().clone()))
+    }
+}
+
+impl<T: Call> Default for MutableConstraint<T> {
+    fn default() -> Self {
+        Self(RwLock::new(EntryVec::default()))
+    }
+}
+
+/// A map of calls.
+#[derive(Clone)]
+struct EntryMap<T: Call>(HashMap<u128, ConstraintEntry<T>>);
+
+impl<T: Call> EntryMap<T> {
+    /// Enter a constraint for a call to a function.
+    #[inline]
+    fn push_inner(&mut self, entry: Cow<ConstraintEntry<T>>) {
+        match self.0.entry(entry.call_hash) {
+            Entry::Occupied(occupied) => {
+                #[cfg(debug_assertions)]
+                check(occupied.get(), &entry);
+            }
+            Entry::Vacant(vacant) => {
+                vacant.insert(entry.into_owned());
+            }
+        }
+    }
+}
+
+impl<T: Call> Default for EntryMap<T> {
+    fn default() -> Self {
+        Self(HashMap::new())
+    }
+}
+
+/// A list of calls.
+///
+/// Order matters here, as those are mutable & immutable calls.
+#[derive(Clone)]
+struct EntryVec<T: Call>(Vec<ConstraintEntry<T>>);
+
+impl<T: Call> EntryVec<T> {
+    /// Enter a constraint for a call to a function.
+    #[inline]
+    fn push_inner(&mut self, entry: Cow<ConstraintEntry<T>>) {
+        // If the call is immutable check whether we already have a call
+        // with the same arguments and return value.
+        if !entry.call.is_mutable() {
+            for prev in self.0.iter().rev() {
+                if entry.call.is_mutable() {
+                    break;
+                }
+
+                if entry.call_hash == prev.call_hash && entry.ret_hash == prev.ret_hash {
+                    #[cfg(debug_assertions)]
+                    check(&entry, prev);
+                    return;
+                }
+            }
+        }
+
+        // Insert the call into the call list.
+        self.0.push(entry.into_owned());
+    }
+}
+
+impl<T: Call> Default for EntryVec<T> {
+    fn default() -> Self {
+        Self(Vec::new())
+    }
+}
+
+/// Extend an outer constraint by an inner one.
+pub trait Join<T = Self> {
+    /// Join this constraint with the `inner` one.
+    fn join(&self, inner: &T);
+
+    /// Take out the constraint.
+    fn take(&self) -> Self;
+}
+
+impl<T: Join> Join<T> for Option<&T> {
+    #[inline]
+    fn join(&self, inner: &T) {
+        if let Some(outer) = self {
+            outer.join(inner);
+        }
+    }
+
+    #[inline]
+    fn take(&self) -> Self {
+        unimplemented!("cannot call `Join::take` on optional constraint")
+    }
+}
+
+impl<T: Call> Join for ImmutableConstraint<T> {
+    #[inline]
+    fn join(&self, inner: &Self) {
+        let mut this = self.0.write();
+        for call in inner.0.read().0.values() {
+            this.push_inner(Cow::Borrowed(call));
+        }
+    }
+
+    #[inline]
+    fn take(&self) -> Self {
+        Self(RwLock::new(std::mem::take(&mut *self.0.write())))
+    }
+}
+
+impl<T: Call> Join for MutableConstraint<T> {
+    #[inline]
+    fn join(&self, inner: &Self) {
+        let mut this = self.0.write();
+        for call in inner.0.read().0.iter() {
+            this.push_inner(Cow::Borrowed(call));
+        }
+    }
+
+    #[inline]
+    fn take(&self) -> Self {
+        Self(RwLock::new(std::mem::take(&mut *self.0.write())))
+    }
+}
+
+/// Produce a 128-bit hash of a value.
+#[inline]
+pub fn hash<T: Hash>(value: &T) -> u128 {
+    let mut state = SipHasher13::new();
+    value.hash(&mut state);
+    state.finish128().as_u128()
+}
+
+/// Check for a constraint violation.
+#[inline]
+#[track_caller]
+#[allow(dead_code)]
+fn check<T: Call>(lhs: &ConstraintEntry<T>, rhs: &ConstraintEntry<T>) {
+    if lhs.ret_hash != rhs.ret_hash {
+        panic!(
+            "comemo: found conflicting constraints. \
+             is this tracked function pure?"
+        )
+    }
+
+    // Additional checks for debugging.
+    if lhs.call_hash != rhs.call_hash || lhs.call != rhs.call {
+        panic!(
+            "comemo: found conflicting `check` arguments. \
+             this is a bug in comemo"
+        )
+    }
+}

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -135,9 +135,9 @@ impl<T: Call> MutableConstraint<T> {
     where
         F: FnMut(&T),
     {
-        for call in &self.0.read().0 {
-            if call.call.is_mutable() {
-                f(&call.call);
+        for entry in &self.0.read().0 {
+            if entry.call.is_mutable() {
+                f(&entry.call);
             }
         }
     }
@@ -245,8 +245,8 @@ impl<T: Call> Join for ImmutableConstraint<T> {
     #[inline]
     fn join(&self, inner: &Self) {
         let mut this = self.0.write();
-        for call in inner.0.read().0.values() {
-            this.push_inner(Cow::Borrowed(call));
+        for entry in inner.0.read().0.values() {
+            this.push_inner(Cow::Borrowed(entry));
         }
     }
 
@@ -260,8 +260,8 @@ impl<T: Call> Join for MutableConstraint<T> {
     #[inline]
     fn join(&self, inner: &Self) {
         let mut this = self.0.write();
-        for call in inner.0.read().0.iter() {
-            this.push_inner(Cow::Borrowed(call));
+        for entry in inner.0.read().0.iter() {
+            this.push_inner(Cow::Borrowed(entry));
         }
     }
 

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -164,9 +164,9 @@ impl<T: Call> EntryMap<T> {
     #[inline]
     fn push_inner(&mut self, entry: Cow<ConstraintEntry<T>>) {
         match self.0.entry(entry.call_hash) {
-            Entry::Occupied(occupied) => {
+            Entry::Occupied(_occupied) => {
                 #[cfg(debug_assertions)]
-                check(occupied.get(), &entry);
+                check(_occupied.get(), &entry);
             }
             Entry::Vacant(vacant) => {
                 vacant.insert(entry.into_owned());

--- a/src/input.rs
+++ b/src/input.rs
@@ -84,7 +84,7 @@ where
 
     #[inline]
     fn validate(&self, constraint: &Self::Constraint) -> bool {
-        self.value.validate_with_accelerator(constraint, &self.accelerator)
+        self.value.validate_with_id(constraint, self.id)
     }
 
     #[inline]
@@ -101,7 +101,7 @@ where
         let tracked = Tracked {
             value: self.value,
             constraint: Some(constraint),
-            accelerator: self.accelerator,
+            id: self.id,
         };
         (tracked, self.constraint)
     }
@@ -121,7 +121,7 @@ where
 
     #[inline]
     fn validate(&self, constraint: &Self::Constraint) -> bool {
-        self.value.validate_with_accelerator(constraint, &self.accelerator)
+        self.value.validate_with_id(constraint, self.id)
     }
 
     #[inline]
@@ -138,7 +138,7 @@ where
         let tracked = Tracked {
             value: self.value,
             constraint: Some(constraint),
-            accelerator: self.accelerator.clone(),
+            id: self.id,
         };
         (tracked, self.constraint)
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,6 +1,6 @@
 use std::hash::{Hash, Hasher};
 
-use crate::cache::Join;
+use crate::constraint::Join;
 use crate::track::{Track, Tracked, TrackedMut, Validate};
 
 /// Ensure a type is suitable as input.

--- a/src/input.rs
+++ b/src/input.rs
@@ -107,79 +107,7 @@ where
     }
 }
 
-impl<'a: 'b, 'b, T> Input for &'b Tracked<'a, T>
-where
-    T: Track + ?Sized,
-{
-    // Forward constraint from `Trackable` implementation.
-    type Constraint = <T as Validate>::Constraint;
-    type Tracked<'r> = Tracked<'r, T> where Self: 'r;
-    type Outer = Option<&'a Self::Constraint>;
-
-    #[inline]
-    fn key<H: Hasher>(&self, _: &mut H) {}
-
-    #[inline]
-    fn validate(&self, constraint: &Self::Constraint) -> bool {
-        self.value.validate_with_id(constraint, self.id)
-    }
-
-    #[inline]
-    fn replay(&mut self, _: &Self::Constraint) {}
-
-    #[inline]
-    fn retrack<'r>(
-        self,
-        constraint: &'r Self::Constraint,
-    ) -> (Self::Tracked<'r>, Self::Outer)
-    where
-        Self: 'r,
-    {
-        let tracked = Tracked {
-            value: self.value,
-            constraint: Some(constraint),
-            id: self.id,
-        };
-        (tracked, self.constraint)
-    }
-}
-
 impl<'a, T> Input for TrackedMut<'a, T>
-where
-    T: Track + ?Sized,
-{
-    // Forward constraint from `Trackable` implementation.
-    type Constraint = T::Constraint;
-    type Tracked<'r> = TrackedMut<'r, T> where Self: 'r;
-    type Outer = Option<&'a Self::Constraint>;
-
-    #[inline]
-    fn key<H: Hasher>(&self, _: &mut H) {}
-
-    #[inline]
-    fn validate(&self, constraint: &Self::Constraint) -> bool {
-        self.value.validate(constraint)
-    }
-
-    #[inline]
-    fn replay(&mut self, constraint: &Self::Constraint) {
-        self.value.replay(constraint);
-    }
-
-    #[inline]
-    fn retrack<'r>(
-        self,
-        constraint: &'r Self::Constraint,
-    ) -> (Self::Tracked<'r>, Self::Outer)
-    where
-        Self: 'r,
-    {
-        let tracked = TrackedMut { value: self.value, constraint: Some(constraint) };
-        (tracked, self.constraint)
-    }
-}
-
-impl<'a: 'b, 'b, T> Input for &'b mut TrackedMut<'a, T>
 where
     T: Track + ?Sized,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,11 @@ pub use comemo_macros::{memoize, track};
 /// These are implementation details. Do not rely on them!
 #[doc(hidden)]
 pub mod internal {
-    pub use crate::cache::{hash, last_was_hit, memoized, Constraint};
-    pub use crate::input::{assert_hashable_or_trackable, Args};
+    pub use crate::cache::{
+        hash, last_was_hit, memoized, register_cache, Cache, Constraint,
+        ImmutableConstraint,
+    };
+    pub use crate::input::{assert_hashable_or_trackable, Args, Input};
     pub use crate::track::{to_parts_mut_mut, to_parts_mut_ref, to_parts_ref, Surfaces};
+    pub use once_cell::sync::Lazy;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,9 @@ For the full example see [`examples/calc.rs`][calc].
 [calc]: https://github.com/typst/comemo/blob/main/examples/calc.rs
 */
 
+mod accelerate;
 mod cache;
+mod constraint;
 mod input;
 mod prehashed;
 mod track;
@@ -97,14 +99,11 @@ pub use comemo_macros::{memoize, track};
 pub mod internal {
     pub use parking_lot::RwLock;
 
-    pub use crate::cache::{
-        hash, memoized, register_cache, Accelerator, Cache, CacheData, Call,
-        ImmutableConstraint, MutableConstraint,
-    };
-
+    pub use crate::cache::{memoized, register_evictor, Cache, CacheData};
+    pub use crate::constraint::{hash, Call, ImmutableConstraint, MutableConstraint};
     pub use crate::input::{assert_hashable_or_trackable, Args, Input};
     pub use crate::track::{to_parts_mut_mut, to_parts_mut_ref, to_parts_ref, Surfaces};
 
-    #[cfg(feature = "last_was_hit")]
+    #[cfg(feature = "testing")]
     pub use crate::cache::last_was_hit;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,8 @@ pub mod internal {
     pub use parking_lot::RwLock;
 
     pub use crate::cache::{
-        hash, memoized, register_cache, Cache, Constraint, ImmutableConstraint,
+        hash, memoized, register_cache, Accelerator, Cache, Constraint,
+        ImmutableConstraint,
     };
 
     pub use crate::input::{assert_hashable_or_trackable, Args, Input};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,13 +98,12 @@ pub mod internal {
     pub use parking_lot::RwLock;
 
     pub use crate::cache::{
-        hash, memoized, register_cache, Accelerator, Cache, Constraint,
-        ImmutableConstraint,
+        hash, memoized, register_cache, Accelerator, Cache, CacheData, Call,
+        ImmutableConstraint, MutableConstraint,
     };
 
     pub use crate::input::{assert_hashable_or_trackable, Args, Input};
     pub use crate::track::{to_parts_mut_mut, to_parts_mut_ref, to_parts_ref, Surfaces};
-    pub use once_cell::sync::Lazy;
 
     #[cfg(feature = "last_was_hit")]
     pub use crate::cache::last_was_hit;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,8 @@ pub use comemo_macros::{memoize, track};
 /// These are implementation details. Do not rely on them!
 #[doc(hidden)]
 pub mod internal {
+    pub use parking_lot::RwLock;
+
     pub use crate::cache::{
         hash, memoized, register_cache, Cache, Constraint, ImmutableConstraint,
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,10 +96,13 @@ pub use comemo_macros::{memoize, track};
 #[doc(hidden)]
 pub mod internal {
     pub use crate::cache::{
-        hash, last_was_hit, memoized, register_cache, Cache, Constraint,
-        ImmutableConstraint,
+        hash, memoized, register_cache, Cache, Constraint, ImmutableConstraint,
     };
+
     pub use crate::input::{assert_hashable_or_trackable, Args, Input};
     pub use crate::track::{to_parts_mut_mut, to_parts_mut_ref, to_parts_ref, Surfaces};
     pub use once_cell::sync::Lazy;
+
+    #[cfg(feature = "last_was_hit")]
+    pub use crate::cache::last_was_hit;
 }

--- a/src/track.rs
+++ b/src/track.rs
@@ -288,7 +288,7 @@ where
 
 /// Destructure a `Tracked<_>` into its parts.
 #[inline]
-pub fn to_parts_ref<'a, T>(tracked: &Tracked<'a, T>) -> (&'a T, Option<&'a T::Constraint>)
+pub fn to_parts_ref<T>(tracked: Tracked<T>) -> (&T, Option<&T::Constraint>)
 where
     T: Track + ?Sized,
 {

--- a/src/track.rs
+++ b/src/track.rs
@@ -1,7 +1,8 @@
 use std::fmt::{self, Debug, Formatter};
 use std::ops::{Deref, DerefMut};
 
-use crate::cache::{id, Join};
+use crate::accelerate;
+use crate::constraint::Join;
 
 /// A trackable type.
 ///
@@ -12,7 +13,11 @@ pub trait Track: Validate + Surfaces {
     /// Start tracking all accesses to a value.
     #[inline]
     fn track(&self) -> Tracked<Self> {
-        Tracked { value: self, constraint: None, id: id() }
+        Tracked {
+            value: self,
+            constraint: None,
+            id: accelerate::id(),
+        }
     }
 
     /// Start tracking all accesses and mutations to a value.
@@ -27,7 +32,7 @@ pub trait Track: Validate + Surfaces {
         Tracked {
             value: self,
             constraint: Some(constraint),
-            id: id(),
+            id: accelerate::id(),
         }
     }
 
@@ -227,7 +232,7 @@ where
         Tracked {
             value: this.value,
             constraint: this.constraint,
-            id: id(),
+            id: accelerate::id(),
         }
     }
 
@@ -240,7 +245,7 @@ where
         Tracked {
             value: this.value,
             constraint: this.constraint,
-            id: id(),
+            id: accelerate::id(),
         }
     }
 

--- a/src/track.rs
+++ b/src/track.rs
@@ -151,7 +151,7 @@ where
     /// Starts out as `None` and is set to a stack-stored constraint in the
     /// preamble of memoized functions.
     pub(crate) constraint: Option<&'a C>,
-    /// The ID of the tracked value.
+    /// A unique ID for validation acceleration.
     pub(crate) id: usize,
 }
 
@@ -180,6 +180,8 @@ where
     }
 }
 
+impl<'a, T> Copy for Tracked<'a, T> where T: Track + ?Sized {}
+
 impl<'a, T> Clone for Tracked<'a, T>
 where
     T: Track + ?Sized,
@@ -189,8 +191,6 @@ where
         *self
     }
 }
-
-impl<'a, T> Copy for Tracked<'a, T> where T: Track + ?Sized {}
 
 /// Tracks accesses and mutations to a value.
 ///

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -212,27 +212,12 @@ fn test_kinds() {
         }
     }
 
-    #[memoize]
-    fn generic<T>(tester: Tracky, name: T) -> String
-    where
-        T: AsRef<str> + Hash,
-    {
-        tester.double_ref(name.as_ref()).to_string()
-    }
-
-    #[memoize]
-    fn ignorant(tester: Tracky, name: impl AsRef<str> + Hash) -> String {
-        tester.arg_ref(name.as_ref()).to_string()
-    }
-
     let mut tester = Tester { data: "Hi".to_string() };
 
     let tracky = tester.track();
     test!(miss: selfie(tracky), "Hi");
     test!(miss: unconditional(tracky), "Short");
     test!(hit: unconditional(tracky), "Short");
-    test!(miss: generic(tracky, "World"), "World");
-    test!(miss: ignorant(tracky, "Ignorant"), "Ignorant");
     test!(hit: selfie(tracky), "Hi");
 
     tester.data.push('!');
@@ -240,15 +225,11 @@ fn test_kinds() {
     let tracky = tester.track();
     test!(miss: selfie(tracky), "Hi!");
     test!(miss: unconditional(tracky), "Short");
-    test!(hit: generic(tracky, "World"), "World");
-    test!(hit: ignorant(tracky, "Ignorant"), "Ignorant");
 
     tester.data.push_str(" Let's go.");
 
     let tracky = tester.track();
     test!(miss: unconditional(tracky), "Long");
-    test!(miss: generic(tracky, "World"), "Hi! Let's go.");
-    test!(hit: ignorant(tracky, "Ignorant"), "Ignorant");
 }
 
 /// Test with type alias.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -3,6 +3,7 @@ use std::hash::Hash;
 use std::path::{Path, PathBuf};
 
 use comemo::{evict, memoize, track, Track, Tracked, TrackedMut, Validate};
+use serial_test::serial;
 
 macro_rules! test {
     (miss: $call:expr, $result:expr) => {{
@@ -17,6 +18,7 @@ macro_rules! test {
 
 /// Test basic memoization.
 #[test]
+#[serial]
 fn test_basic() {
     #[memoize]
     fn empty() -> String {
@@ -71,6 +73,7 @@ fn test_basic() {
 
 /// Test the calc language.
 #[test]
+#[serial]
 fn test_calc() {
     #[memoize]
     fn evaluate(script: &str, files: Tracked<Files>) -> i32 {
@@ -116,6 +119,7 @@ impl Files {
 
 /// Test cache eviction.
 #[test]
+#[serial]
 fn test_evict() {
     #[memoize]
     fn null() -> u8 {
@@ -141,6 +145,7 @@ fn test_evict() {
 
 /// Test tracking a trait object.
 #[test]
+#[serial]
 fn test_tracked_trait() {
     #[memoize]
     fn traity(loader: Tracked<dyn Loader + '_>, path: &Path) -> Vec<u8> {
@@ -172,6 +177,7 @@ impl Loader for StaticLoader {
 
 /// Test memoized methods.
 #[test]
+#[serial]
 fn test_memoized_methods() {
     #[derive(Hash)]
     struct Taker(String);
@@ -197,6 +203,7 @@ fn test_memoized_methods() {
 
 /// Test different kinds of arguments.
 #[test]
+#[serial]
 fn test_kinds() {
     #[memoize]
     fn selfie(tester: Tracky) -> String {
@@ -277,6 +284,7 @@ impl Empty {}
 
 /// Test tracking a type with a lifetime.
 #[test]
+#[serial]
 fn test_lifetime() {
     #[comemo::memoize]
     fn contains_hello(lifeful: Tracked<Lifeful>) -> bool {
@@ -304,6 +312,7 @@ impl<'a> Lifeful<'a> {
 
 /// Test tracking a type with a chain of tracked values.
 #[test]
+#[serial]
 fn test_chain() {
     #[comemo::memoize]
     fn process(chain: Tracked<Chain>, value: u32) -> bool {
@@ -329,6 +338,7 @@ fn test_chain() {
 
 /// Test that `Tracked<T>` is covariant over `T`.
 #[test]
+#[serial]
 #[allow(unused, clippy::needless_lifetimes)]
 fn test_variance() {
     fn foo<'a>(_: Tracked<'a, Chain<'a>>) {}
@@ -366,6 +376,7 @@ impl<'a> Chain<'a> {
 
 /// Test mutable tracking.
 #[test]
+#[serial]
 #[rustfmt::skip]
 fn test_mutable() {
     #[comemo::memoize]
@@ -414,6 +425,7 @@ struct Heavy(String);
 
 /// Test a tracked method that is impure.
 #[test]
+#[serial]
 #[cfg(debug_assertions)]
 #[should_panic(
     expected = "comemo: found conflicting constraints. is this tracked function pure?"

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -150,18 +150,15 @@ mod tests {
     #[serial]
     fn test_tracked_trait() {
         #[memoize]
-        fn traity(
-            loader: Tracked<dyn Loader + Send + Sync + '_>,
-            path: &Path,
-        ) -> Vec<u8> {
+        fn traity(loader: Tracked<dyn Loader + '_>, path: &Path) -> Vec<u8> {
             loader.load(path).unwrap()
         }
 
-        fn wrapper(loader: &(dyn Loader + Send + Sync), path: &Path) -> Vec<u8> {
+        fn wrapper(loader: &(dyn Loader), path: &Path) -> Vec<u8> {
             traity(loader.track(), path)
         }
 
-        let loader: &(dyn Loader + Send + Sync) = &StaticLoader;
+        let loader: &(dyn Loader) = &StaticLoader;
         test!(miss: traity(loader.track(), Path::new("hi.rs")), [1, 2, 3]);
         test!(hit: traity(loader.track(), Path::new("hi.rs")), [1, 2, 3]);
         test!(miss: traity(loader.track(), Path::new("bye.rs")), [1, 2, 3]);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -148,15 +148,15 @@ fn test_evict() {
 #[serial]
 fn test_tracked_trait() {
     #[memoize]
-    fn traity(loader: Tracked<dyn Loader + '_>, path: &Path) -> Vec<u8> {
+    fn traity(loader: Tracked<dyn Loader + Send + Sync + '_>, path: &Path) -> Vec<u8> {
         loader.load(path).unwrap()
     }
 
-    fn wrapper(loader: &dyn Loader, path: &Path) -> Vec<u8> {
+    fn wrapper(loader: &(dyn Loader + Send + Sync), path: &Path) -> Vec<u8> {
         traity(loader.track(), path)
     }
 
-    let loader: &dyn Loader = &StaticLoader;
+    let loader: &(dyn Loader + Send + Sync) = &StaticLoader;
     test!(miss: traity(loader.track(), Path::new("hi.rs")), [1, 2, 3]);
     test!(hit: traity(loader.track(), Path::new("hi.rs")), [1, 2, 3]);
     test!(miss: traity(loader.track(), Path::new("bye.rs")), [1, 2, 3]);
@@ -164,7 +164,7 @@ fn test_tracked_trait() {
 }
 
 #[track]
-trait Loader {
+trait Loader: Send + Sync {
     fn load(&self, path: &Path) -> Result<Vec<u8>, String>;
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,453 +1,458 @@
-use std::collections::HashMap;
-use std::hash::Hash;
-use std::path::{Path, PathBuf};
+#[cfg(feature = "last_was_hit")]
+mod tests {
+    use std::collections::HashMap;
+    use std::hash::Hash;
+    use std::path::{Path, PathBuf};
 
-use comemo::{evict, memoize, track, Track, Tracked, TrackedMut, Validate};
-use serial_test::serial;
+    use comemo::{evict, memoize, track, Track, Tracked, TrackedMut, Validate};
+    use serial_test::serial;
 
-macro_rules! test {
-    (miss: $call:expr, $result:expr) => {{
-        assert_eq!($call, $result);
-        assert!(!comemo::internal::last_was_hit());
-    }};
-    (hit: $call:expr, $result:expr) => {{
-        assert_eq!($call, $result);
-        assert!(comemo::internal::last_was_hit());
-    }};
-}
-
-/// Test basic memoization.
-#[test]
-#[serial]
-fn test_basic() {
-    #[memoize]
-    fn empty() -> String {
-        format!("The world is {}", "big")
+    macro_rules! test {
+        (miss: $call:expr, $result:expr) => {{
+            assert_eq!($call, $result);
+            assert!(!comemo::internal::last_was_hit());
+        }};
+        (hit: $call:expr, $result:expr) => {{
+            assert_eq!($call, $result);
+            assert!(comemo::internal::last_was_hit());
+        }};
     }
 
-    #[memoize]
-    fn double(x: u32) -> u32 {
-        2 * x
-    }
-
-    #[memoize]
-    fn sum(a: u32, b: u32) -> u32 {
-        a + b
-    }
-
-    #[memoize]
-    fn fib(n: u32) -> u32 {
-        if n <= 2 {
-            1
-        } else {
-            fib(n - 1) + fib(n - 2)
-        }
-    }
-
-    #[memoize]
-    fn sum_iter(n: u32) -> u32 {
-        (0..n).sum()
-    }
-
-    test!(miss: empty(), "The world is big");
-    test!(hit: empty(), "The world is big");
-    test!(hit: empty(), "The world is big");
-
-    test!(miss: double(2), 4);
-    test!(miss: double(4), 8);
-    test!(hit: double(2), 4);
-
-    test!(miss: sum(2, 4), 6);
-    test!(miss: sum(2, 3), 5);
-    test!(hit: sum(2, 3), 5);
-    test!(miss: sum(4, 2), 6);
-
-    test!(miss: fib(5), 5);
-    test!(hit: fib(3), 2);
-    test!(miss: fib(8), 21);
-    test!(hit: fib(7), 13);
-
-    test!(miss: sum_iter(1000), 499500);
-    test!(hit: sum_iter(1000), 499500);
-}
-
-/// Test the calc language.
-#[test]
-#[serial]
-fn test_calc() {
-    #[memoize]
-    fn evaluate(script: &str, files: Tracked<Files>) -> i32 {
-        script
-            .split('+')
-            .map(str::trim)
-            .map(|part| match part.strip_prefix("eval ") {
-                Some(path) => evaluate(&files.read(path), files),
-                None => part.parse::<i32>().unwrap(),
-            })
-            .sum()
-    }
-
-    let mut files = Files(HashMap::new());
-    files.write("alpha.calc", "2 + eval beta.calc");
-    files.write("beta.calc", "2 + 3");
-    files.write("gamma.calc", "8 + 3");
-    test!(miss: evaluate("eval alpha.calc", files.track()), 7);
-    test!(miss: evaluate("eval beta.calc", files.track()), 5);
-    files.write("gamma.calc", "42");
-    test!(hit: evaluate("eval alpha.calc", files.track()), 7);
-    files.write("beta.calc", "4 + eval gamma.calc");
-    test!(miss: evaluate("eval beta.calc", files.track()), 46);
-    test!(miss: evaluate("eval alpha.calc", files.track()), 48);
-    files.write("gamma.calc", "80");
-    test!(miss: evaluate("eval alpha.calc", files.track()), 86);
-}
-
-struct Files(HashMap<PathBuf, String>);
-
-#[track]
-impl Files {
-    fn read(&self, path: &str) -> String {
-        self.0.get(Path::new(path)).cloned().unwrap_or_default()
-    }
-}
-
-impl Files {
-    fn write(&mut self, path: &str, text: &str) {
-        self.0.insert(path.into(), text.into());
-    }
-}
-
-/// Test cache eviction.
-#[test]
-#[serial]
-fn test_evict() {
-    #[memoize]
-    fn null() -> u8 {
-        0
-    }
-
-    test!(miss: null(), 0);
-    test!(hit: null(), 0);
-    evict(2);
-    test!(hit: null(), 0);
-    evict(2);
-    evict(2);
-    test!(hit: null(), 0);
-    evict(2);
-    evict(2);
-    evict(2);
-    test!(miss: null(), 0);
-    test!(hit: null(), 0);
-    evict(0);
-    test!(miss: null(), 0);
-    test!(hit: null(), 0);
-}
-
-/// Test tracking a trait object.
-#[test]
-#[serial]
-fn test_tracked_trait() {
-    #[memoize]
-    fn traity(loader: Tracked<dyn Loader + Send + Sync + '_>, path: &Path) -> Vec<u8> {
-        loader.load(path).unwrap()
-    }
-
-    fn wrapper(loader: &(dyn Loader + Send + Sync), path: &Path) -> Vec<u8> {
-        traity(loader.track(), path)
-    }
-
-    let loader: &(dyn Loader + Send + Sync) = &StaticLoader;
-    test!(miss: traity(loader.track(), Path::new("hi.rs")), [1, 2, 3]);
-    test!(hit: traity(loader.track(), Path::new("hi.rs")), [1, 2, 3]);
-    test!(miss: traity(loader.track(), Path::new("bye.rs")), [1, 2, 3]);
-    wrapper(loader, Path::new("hi.rs"));
-}
-
-#[track]
-trait Loader: Send + Sync {
-    fn load(&self, path: &Path) -> Result<Vec<u8>, String>;
-}
-
-struct StaticLoader;
-impl Loader for StaticLoader {
-    fn load(&self, _: &Path) -> Result<Vec<u8>, String> {
-        Ok(vec![1, 2, 3])
-    }
-}
-
-/// Test memoized methods.
-#[test]
-#[serial]
-fn test_memoized_methods() {
-    #[derive(Hash)]
-    struct Taker(String);
-
-    /// Has memoized methods.
-    impl Taker {
+    /// Test basic memoization.
+    #[test]
+    #[serial]
+    fn test_basic() {
         #[memoize]
-        fn copy(&self) -> String {
-            self.0.clone()
+        fn empty() -> String {
+            format!("The world is {}", "big")
         }
 
         #[memoize]
-        fn take(self) -> String {
-            self.0
+        fn double(x: u32) -> u32 {
+            2 * x
+        }
+
+        #[memoize]
+        fn sum(a: u32, b: u32) -> u32 {
+            a + b
+        }
+
+        #[memoize]
+        fn fib(n: u32) -> u32 {
+            if n <= 2 {
+                1
+            } else {
+                fib(n - 1) + fib(n - 2)
+            }
+        }
+
+        #[memoize]
+        fn sum_iter(n: u32) -> u32 {
+            (0..n).sum()
+        }
+
+        test!(miss: empty(), "The world is big");
+        test!(hit: empty(), "The world is big");
+        test!(hit: empty(), "The world is big");
+
+        test!(miss: double(2), 4);
+        test!(miss: double(4), 8);
+        test!(hit: double(2), 4);
+
+        test!(miss: sum(2, 4), 6);
+        test!(miss: sum(2, 3), 5);
+        test!(hit: sum(2, 3), 5);
+        test!(miss: sum(4, 2), 6);
+
+        test!(miss: fib(5), 5);
+        test!(hit: fib(3), 2);
+        test!(miss: fib(8), 21);
+        test!(hit: fib(7), 13);
+
+        test!(miss: sum_iter(1000), 499500);
+        test!(hit: sum_iter(1000), 499500);
+    }
+
+    /// Test the calc language.
+    #[test]
+    #[serial]
+    fn test_calc() {
+        #[memoize]
+        fn evaluate(script: &str, files: Tracked<Files>) -> i32 {
+            script
+                .split('+')
+                .map(str::trim)
+                .map(|part| match part.strip_prefix("eval ") {
+                    Some(path) => evaluate(&files.read(path), files),
+                    None => part.parse::<i32>().unwrap(),
+                })
+                .sum()
+        }
+
+        let mut files = Files(HashMap::new());
+        files.write("alpha.calc", "2 + eval beta.calc");
+        files.write("beta.calc", "2 + 3");
+        files.write("gamma.calc", "8 + 3");
+        test!(miss: evaluate("eval alpha.calc", files.track()), 7);
+        test!(miss: evaluate("eval beta.calc", files.track()), 5);
+        files.write("gamma.calc", "42");
+        test!(hit: evaluate("eval alpha.calc", files.track()), 7);
+        files.write("beta.calc", "4 + eval gamma.calc");
+        test!(miss: evaluate("eval beta.calc", files.track()), 46);
+        test!(miss: evaluate("eval alpha.calc", files.track()), 48);
+        files.write("gamma.calc", "80");
+        test!(miss: evaluate("eval alpha.calc", files.track()), 86);
+    }
+
+    struct Files(HashMap<PathBuf, String>);
+
+    #[track]
+    impl Files {
+        fn read(&self, path: &str) -> String {
+            self.0.get(Path::new(path)).cloned().unwrap_or_default()
         }
     }
 
-    test!(miss: Taker("Hello".into()).take(), "Hello");
-    test!(miss: Taker("Hello".into()).copy(), "Hello");
-    test!(miss: Taker("World".into()).take(), "World");
-    test!(hit: Taker("Hello".into()).take(), "Hello");
-}
-
-/// Test different kinds of arguments.
-#[test]
-#[serial]
-fn test_kinds() {
-    #[memoize]
-    fn selfie(tester: Tracky) -> String {
-        tester.self_ref().into()
-    }
-
-    #[memoize]
-    fn unconditional(tester: Tracky) -> &'static str {
-        if tester.by_value(Heavy("HEAVY".into())) > 10 {
-            "Long"
-        } else {
-            "Short"
+    impl Files {
+        fn write(&mut self, path: &str, text: &str) {
+            self.0.insert(path.into(), text.into());
         }
     }
 
-    let mut tester = Tester { data: "Hi".to_string() };
+    /// Test cache eviction.
+    #[test]
+    #[serial]
+    fn test_evict() {
+        #[memoize]
+        fn null() -> u8 {
+            0
+        }
 
-    let tracky = tester.track();
-    test!(miss: selfie(tracky.clone()), "Hi");
-    test!(miss: unconditional(tracky.clone()), "Short");
-    test!(hit: unconditional(tracky.clone()), "Short");
-    test!(hit: selfie(tracky), "Hi");
-
-    tester.data.push('!');
-
-    let tracky = tester.track();
-    test!(miss: selfie(tracky.clone()), "Hi!");
-    test!(miss: unconditional(tracky), "Short");
-
-    tester.data.push_str(" Let's go.");
-
-    let tracky = tester.track();
-    test!(miss: unconditional(tracky), "Long");
-}
-
-/// Test with type alias.
-type Tracky<'a> = comemo::Tracked<'a, Tester>;
-
-/// A struct with some data.
-struct Tester {
-    data: String,
-}
-
-/// Tests different kinds of arguments.
-#[track]
-impl Tester {
-    /// Return value can borrow from self.
-    #[allow(clippy::needless_lifetimes)]
-    fn self_ref<'a>(&'a self) -> &'a str {
-        &self.data
+        test!(miss: null(), 0);
+        test!(hit: null(), 0);
+        evict(2);
+        test!(hit: null(), 0);
+        evict(2);
+        evict(2);
+        test!(hit: null(), 0);
+        evict(2);
+        evict(2);
+        evict(2);
+        test!(miss: null(), 0);
+        test!(hit: null(), 0);
+        evict(0);
+        test!(miss: null(), 0);
+        test!(hit: null(), 0);
     }
 
-    /// Return value can borrow from argument.
-    fn arg_ref<'a>(&self, name: &'a str) -> &'a str {
-        name
+    /// Test tracking a trait object.
+    #[test]
+    #[serial]
+    fn test_tracked_trait() {
+        #[memoize]
+        fn traity(
+            loader: Tracked<dyn Loader + Send + Sync + '_>,
+            path: &Path,
+        ) -> Vec<u8> {
+            loader.load(path).unwrap()
+        }
+
+        fn wrapper(loader: &(dyn Loader + Send + Sync), path: &Path) -> Vec<u8> {
+            traity(loader.track(), path)
+        }
+
+        let loader: &(dyn Loader + Send + Sync) = &StaticLoader;
+        test!(miss: traity(loader.track(), Path::new("hi.rs")), [1, 2, 3]);
+        test!(hit: traity(loader.track(), Path::new("hi.rs")), [1, 2, 3]);
+        test!(miss: traity(loader.track(), Path::new("bye.rs")), [1, 2, 3]);
+        wrapper(loader, Path::new("hi.rs"));
     }
 
-    /// Return value can borrow from both.
-    fn double_ref<'a>(&'a self, name: &'a str) -> &'a str {
-        if name.len() > self.data.len() {
-            name
-        } else {
+    #[track]
+    trait Loader: Send + Sync {
+        fn load(&self, path: &Path) -> Result<Vec<u8>, String>;
+    }
+
+    struct StaticLoader;
+    impl Loader for StaticLoader {
+        fn load(&self, _: &Path) -> Result<Vec<u8>, String> {
+            Ok(vec![1, 2, 3])
+        }
+    }
+
+    /// Test memoized methods.
+    #[test]
+    #[serial]
+    fn test_memoized_methods() {
+        #[derive(Hash)]
+        struct Taker(String);
+
+        /// Has memoized methods.
+        impl Taker {
+            #[memoize]
+            fn copy(&self) -> String {
+                self.0.clone()
+            }
+
+            #[memoize]
+            fn take(self) -> String {
+                self.0
+            }
+        }
+
+        test!(miss: Taker("Hello".into()).take(), "Hello");
+        test!(miss: Taker("Hello".into()).copy(), "Hello");
+        test!(miss: Taker("World".into()).take(), "World");
+        test!(hit: Taker("Hello".into()).take(), "Hello");
+    }
+
+    /// Test different kinds of arguments.
+    #[test]
+    #[serial]
+    fn test_kinds() {
+        #[memoize]
+        fn selfie(tester: Tracky) -> String {
+            tester.self_ref().into()
+        }
+
+        #[memoize]
+        fn unconditional(tester: Tracky) -> &'static str {
+            if tester.by_value(Heavy("HEAVY".into())) > 10 {
+                "Long"
+            } else {
+                "Short"
+            }
+        }
+
+        let mut tester = Tester { data: "Hi".to_string() };
+
+        let tracky = tester.track();
+        test!(miss: selfie(tracky), "Hi");
+        test!(miss: unconditional(tracky), "Short");
+        test!(hit: unconditional(tracky), "Short");
+        test!(hit: selfie(tracky), "Hi");
+
+        tester.data.push('!');
+
+        let tracky = tester.track();
+        test!(miss: selfie(tracky), "Hi!");
+        test!(miss: unconditional(tracky), "Short");
+
+        tester.data.push_str(" Let's go.");
+
+        let tracky = tester.track();
+        test!(miss: unconditional(tracky), "Long");
+    }
+
+    /// Test with type alias.
+    type Tracky<'a> = comemo::Tracked<'a, Tester>;
+
+    /// A struct with some data.
+    struct Tester {
+        data: String,
+    }
+
+    /// Tests different kinds of arguments.
+    #[track]
+    impl Tester {
+        /// Return value can borrow from self.
+        #[allow(clippy::needless_lifetimes)]
+        fn self_ref<'a>(&'a self) -> &'a str {
             &self.data
         }
+
+        /// Return value can borrow from argument.
+        fn arg_ref<'a>(&self, name: &'a str) -> &'a str {
+            name
+        }
+
+        /// Return value can borrow from both.
+        fn double_ref<'a>(&'a self, name: &'a str) -> &'a str {
+            if name.len() > self.data.len() {
+                name
+            } else {
+                &self.data
+            }
+        }
+
+        /// Normal method with owned argument.
+        fn by_value(&self, heavy: Heavy) -> usize {
+            self.data.len() + heavy.0.len()
+        }
     }
 
-    /// Normal method with owned argument.
-    fn by_value(&self, heavy: Heavy) -> usize {
-        self.data.len() + heavy.0.len()
-    }
-}
+    /// Test empty type without methods.
+    struct Empty;
 
-/// Test empty type without methods.
-struct Empty;
+    #[track]
+    impl Empty {}
 
-#[track]
-impl Empty {}
+    /// Test tracking a type with a lifetime.
+    #[test]
+    #[serial]
+    fn test_lifetime() {
+        #[comemo::memoize]
+        fn contains_hello(lifeful: Tracked<Lifeful>) -> bool {
+            lifeful.contains("hello")
+        }
 
-/// Test tracking a type with a lifetime.
-#[test]
-#[serial]
-fn test_lifetime() {
-    #[comemo::memoize]
-    fn contains_hello(lifeful: Tracked<Lifeful>) -> bool {
-        lifeful.contains("hello")
-    }
+        let lifeful = Lifeful("hey");
+        test!(miss: contains_hello(lifeful.track()), false);
+        test!(hit: contains_hello(lifeful.track()), false);
 
-    let lifeful = Lifeful("hey");
-    test!(miss: contains_hello(lifeful.track()), false);
-    test!(hit: contains_hello(lifeful.track()), false);
-
-    let lifeful = Lifeful("hello");
-    test!(miss: contains_hello(lifeful.track()), true);
-    test!(hit: contains_hello(lifeful.track()), true);
-}
-
-/// Test tracked with lifetime.
-struct Lifeful<'a>(&'a str);
-
-#[track]
-impl<'a> Lifeful<'a> {
-    fn contains(&self, text: &str) -> bool {
-        self.0 == text
-    }
-}
-
-/// Test tracking a type with a chain of tracked values.
-#[test]
-#[serial]
-fn test_chain() {
-    #[comemo::memoize]
-    fn process(chain: Tracked<Chain>, value: u32) -> bool {
-        chain.contains(value)
+        let lifeful = Lifeful("hello");
+        test!(miss: contains_hello(lifeful.track()), true);
+        test!(hit: contains_hello(lifeful.track()), true);
     }
 
-    let chain1 = Chain::new(1);
-    let chain3 = Chain::new(3);
-    let chain12 = Chain::insert(chain1.track(), 2);
-    let chain123 = Chain::insert(chain12.track(), 3);
-    let chain124 = Chain::insert(chain12.track(), 4);
-    let chain1245 = Chain::insert(chain124.track(), 5);
+    /// Test tracked with lifetime.
+    struct Lifeful<'a>(&'a str);
 
-    test!(miss: process(chain1.track(), 0), false);
-    test!(miss: process(chain1.track(), 1), true);
-    test!(miss: process(chain123.track(), 2), true);
-    test!(hit: process(chain124.track(), 2), true);
-    test!(hit: process(chain12.track(), 2), true);
-    test!(hit: process(chain1245.track(), 2), true);
-    test!(miss: process(chain1.track(), 2), false);
-    test!(hit: process(chain3.track(), 2), false);
-}
-
-/// Test that `Tracked<T>` is covariant over `T`.
-#[test]
-#[serial]
-#[allow(unused, clippy::needless_lifetimes)]
-fn test_variance() {
-    fn foo<'a>(_: Tracked<'a, Chain<'a>>) {}
-    fn bar<'a>(chain: Tracked<'a, Chain<'static>>) {
-        foo(chain);
-    }
-}
-
-/// Test tracked with lifetime.
-struct Chain<'a> {
-    // Need to override the lifetime here so that a `Tracked` is covariant over
-    // `Chain`.
-    outer: Option<Tracked<'a, Self, <Chain<'static> as Validate>::Constraint>>,
-    value: u32,
-}
-
-impl<'a> Chain<'a> {
-    /// Create a new chain entry point.
-    fn new(value: u32) -> Self {
-        Self { outer: None, value }
+    #[track]
+    impl<'a> Lifeful<'a> {
+        fn contains(&self, text: &str) -> bool {
+            self.0 == text
+        }
     }
 
-    /// Insert a link into the chain.
-    fn insert(outer: Tracked<'a, Self>, value: u32) -> Self {
-        Chain { outer: Some(outer), value }
-    }
-}
+    /// Test tracking a type with a chain of tracked values.
+    #[test]
+    #[serial]
+    fn test_chain() {
+        #[comemo::memoize]
+        fn process(chain: Tracked<Chain>, value: u32) -> bool {
+            chain.contains(value)
+        }
 
-#[track]
-impl<'a> Chain<'a> {
-    fn contains(&self, value: u32) -> bool {
-        self.value == value
-            || self.outer.as_ref().map_or(false, |outer| outer.contains(value))
-    }
-}
+        let chain1 = Chain::new(1);
+        let chain3 = Chain::new(3);
+        let chain12 = Chain::insert(chain1.track(), 2);
+        let chain123 = Chain::insert(chain12.track(), 3);
+        let chain124 = Chain::insert(chain12.track(), 4);
+        let chain1245 = Chain::insert(chain124.track(), 5);
 
-/// Test mutable tracking.
-#[test]
-#[serial]
-#[rustfmt::skip]
-fn test_mutable() {
-    #[comemo::memoize]
-    fn dump(mut sink: TrackedMut<Emitter>) {
-        sink.emit("a");
-        sink.emit("b");
-        let c = sink.len_or_ten().to_string();
-        sink.emit(&c);
-    }
-
-    let mut emitter = Emitter(vec![]);
-    test!(miss: dump(emitter.track_mut()), ());
-    test!(miss: dump(emitter.track_mut()), ());
-    test!(miss: dump(emitter.track_mut()), ());
-    test!(miss: dump(emitter.track_mut()), ());
-    test!(hit: dump(emitter.track_mut()), ());
-    test!(hit: dump(emitter.track_mut()), ());
-    assert_eq!(emitter.0, [
-        "a", "b", "2",
-        "a", "b", "5",
-        "a", "b", "8",
-        "a", "b", "10",
-        "a", "b", "10",
-        "a", "b", "10",
-    ])
-}
-
-/// A tracked type with a mutable and an immutable method.
-#[derive(Clone)]
-struct Emitter(Vec<String>);
-
-#[track]
-impl Emitter {
-    fn emit(&mut self, msg: &str) {
-        self.0.push(msg.into());
+        test!(miss: process(chain1.track(), 0), false);
+        test!(miss: process(chain1.track(), 1), true);
+        test!(miss: process(chain123.track(), 2), true);
+        test!(hit: process(chain124.track(), 2), true);
+        test!(hit: process(chain12.track(), 2), true);
+        test!(hit: process(chain1245.track(), 2), true);
+        test!(miss: process(chain1.track(), 2), false);
+        test!(hit: process(chain3.track(), 2), false);
     }
 
-    fn len_or_ten(&self) -> usize {
-        self.0.len().min(10)
-    }
-}
-
-/// A non-copy struct that is passed by value to a tracked method.
-#[derive(Clone, PartialEq, Hash)]
-struct Heavy(String);
-
-/// Test a tracked method that is impure.
-#[test]
-#[serial]
-#[cfg(debug_assertions)]
-#[should_panic(
-    expected = "comemo: found conflicting constraints. is this tracked function pure?"
-)]
-fn test_impure_tracked_method() {
-    #[comemo::memoize]
-    fn call(impure: Tracked<Impure>) -> u32 {
-        impure.impure();
-        impure.impure()
+    /// Test that `Tracked<T>` is covariant over `T`.
+    #[test]
+    #[serial]
+    #[allow(unused, clippy::needless_lifetimes)]
+    fn test_variance() {
+        fn foo<'a>(_: Tracked<'a, Chain<'a>>) {}
+        fn bar<'a>(chain: Tracked<'a, Chain<'static>>) {
+            foo(chain);
+        }
     }
 
-    call(Impure.track());
-}
+    /// Test tracked with lifetime.
+    struct Chain<'a> {
+        // Need to override the lifetime here so that a `Tracked` is covariant over
+        // `Chain`.
+        outer: Option<Tracked<'a, Self, <Chain<'static> as Validate>::Constraint>>,
+        value: u32,
+    }
 
-struct Impure;
+    impl<'a> Chain<'a> {
+        /// Create a new chain entry point.
+        fn new(value: u32) -> Self {
+            Self { outer: None, value }
+        }
 
-#[track]
-impl Impure {
-    fn impure(&self) -> u32 {
-        use std::sync::atomic::{AtomicU32, Ordering};
-        static VAL: AtomicU32 = AtomicU32::new(0);
-        VAL.fetch_add(1, Ordering::SeqCst)
+        /// Insert a link into the chain.
+        fn insert(outer: Tracked<'a, Self>, value: u32) -> Self {
+            Chain { outer: Some(outer), value }
+        }
+    }
+
+    #[track]
+    impl<'a> Chain<'a> {
+        fn contains(&self, value: u32) -> bool {
+            self.value == value || self.outer.map_or(false, |outer| outer.contains(value))
+        }
+    }
+
+    /// Test mutable tracking.
+    #[test]
+    #[serial]
+    #[rustfmt::skip]
+    fn test_mutable() {
+        #[comemo::memoize]
+        fn dump(mut sink: TrackedMut<Emitter>) {
+            sink.emit("a");
+            sink.emit("b");
+            let c = sink.len_or_ten().to_string();
+            sink.emit(&c);
+        }
+    
+        let mut emitter = Emitter(vec![]);
+        test!(miss: dump(emitter.track_mut()), ());
+        test!(miss: dump(emitter.track_mut()), ());
+        test!(miss: dump(emitter.track_mut()), ());
+        test!(miss: dump(emitter.track_mut()), ());
+        test!(hit: dump(emitter.track_mut()), ());
+        test!(hit: dump(emitter.track_mut()), ());
+        assert_eq!(emitter.0, [
+            "a", "b", "2",
+            "a", "b", "5",
+            "a", "b", "8",
+            "a", "b", "10",
+            "a", "b", "10",
+            "a", "b", "10",
+        ])
+    }
+
+    /// A tracked type with a mutable and an immutable method.
+    #[derive(Clone)]
+    struct Emitter(Vec<String>);
+
+    #[track]
+    impl Emitter {
+        fn emit(&mut self, msg: &str) {
+            self.0.push(msg.into());
+        }
+
+        fn len_or_ten(&self) -> usize {
+            self.0.len().min(10)
+        }
+    }
+
+    /// A non-copy struct that is passed by value to a tracked method.
+    #[derive(Clone, PartialEq, Hash)]
+    struct Heavy(String);
+
+    /// Test a tracked method that is impure.
+    #[test]
+    #[serial]
+    #[cfg(debug_assertions)]
+    #[should_panic(
+        expected = "comemo: found conflicting constraints. is this tracked function pure?"
+    )]
+    fn test_impure_tracked_method() {
+        #[comemo::memoize]
+        fn call(impure: Tracked<Impure>) -> u32 {
+            impure.impure();
+            impure.impure()
+        }
+
+        call(Impure.track());
+    }
+
+    struct Impure;
+
+    #[track]
+    impl Impure {
+        fn impure(&self) -> u32 {
+            use std::sync::atomic::{AtomicU32, Ordering};
+            static VAL: AtomicU32 = AtomicU32::new(0);
+            VAL.fetch_add(1, Ordering::SeqCst)
+        }
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,382 +1,382 @@
-#[cfg(feature = "last_was_hit")]
-mod tests {
-    use std::collections::HashMap;
-    use std::hash::Hash;
-    use std::path::{Path, PathBuf};
+//! Run with `cargo test --all-features`.
 
-    use comemo::{evict, memoize, track, Track, Tracked, TrackedMut, Validate};
-    use serial_test::serial;
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::path::{Path, PathBuf};
 
-    macro_rules! test {
-        (miss: $call:expr, $result:expr) => {{
-            assert_eq!($call, $result);
-            assert!(!comemo::internal::last_was_hit());
-        }};
-        (hit: $call:expr, $result:expr) => {{
-            assert_eq!($call, $result);
-            assert!(comemo::internal::last_was_hit());
-        }};
+use comemo::{evict, memoize, track, Track, Tracked, TrackedMut, Validate};
+use serial_test::serial;
+
+macro_rules! test {
+    (miss: $call:expr, $result:expr) => {{
+        assert_eq!($call, $result);
+        assert!(!comemo::internal::last_was_hit());
+    }};
+    (hit: $call:expr, $result:expr) => {{
+        assert_eq!($call, $result);
+        assert!(comemo::internal::last_was_hit());
+    }};
+}
+
+/// Test basic memoization.
+#[test]
+#[serial]
+fn test_basic() {
+    #[memoize]
+    fn empty() -> String {
+        format!("The world is {}", "big")
     }
 
-    /// Test basic memoization.
-    #[test]
-    #[serial]
-    fn test_basic() {
+    #[memoize]
+    fn double(x: u32) -> u32 {
+        2 * x
+    }
+
+    #[memoize]
+    fn sum(a: u32, b: u32) -> u32 {
+        a + b
+    }
+
+    #[memoize]
+    fn fib(n: u32) -> u32 {
+        if n <= 2 {
+            1
+        } else {
+            fib(n - 1) + fib(n - 2)
+        }
+    }
+
+    #[memoize]
+    fn sum_iter(n: u32) -> u32 {
+        (0..n).sum()
+    }
+
+    test!(miss: empty(), "The world is big");
+    test!(hit: empty(), "The world is big");
+    test!(hit: empty(), "The world is big");
+
+    test!(miss: double(2), 4);
+    test!(miss: double(4), 8);
+    test!(hit: double(2), 4);
+
+    test!(miss: sum(2, 4), 6);
+    test!(miss: sum(2, 3), 5);
+    test!(hit: sum(2, 3), 5);
+    test!(miss: sum(4, 2), 6);
+
+    test!(miss: fib(5), 5);
+    test!(hit: fib(3), 2);
+    test!(miss: fib(8), 21);
+    test!(hit: fib(7), 13);
+
+    test!(miss: sum_iter(1000), 499500);
+    test!(hit: sum_iter(1000), 499500);
+}
+
+/// Test the calc language.
+#[test]
+#[serial]
+fn test_calc() {
+    #[memoize]
+    fn evaluate(script: &str, files: Tracked<Files>) -> i32 {
+        script
+            .split('+')
+            .map(str::trim)
+            .map(|part| match part.strip_prefix("eval ") {
+                Some(path) => evaluate(&files.read(path), files),
+                None => part.parse::<i32>().unwrap(),
+            })
+            .sum()
+    }
+
+    let mut files = Files(HashMap::new());
+    files.write("alpha.calc", "2 + eval beta.calc");
+    files.write("beta.calc", "2 + 3");
+    files.write("gamma.calc", "8 + 3");
+    test!(miss: evaluate("eval alpha.calc", files.track()), 7);
+    test!(miss: evaluate("eval beta.calc", files.track()), 5);
+    files.write("gamma.calc", "42");
+    test!(hit: evaluate("eval alpha.calc", files.track()), 7);
+    files.write("beta.calc", "4 + eval gamma.calc");
+    test!(miss: evaluate("eval beta.calc", files.track()), 46);
+    test!(miss: evaluate("eval alpha.calc", files.track()), 48);
+    files.write("gamma.calc", "80");
+    test!(miss: evaluate("eval alpha.calc", files.track()), 86);
+}
+
+struct Files(HashMap<PathBuf, String>);
+
+#[track]
+impl Files {
+    fn read(&self, path: &str) -> String {
+        self.0.get(Path::new(path)).cloned().unwrap_or_default()
+    }
+}
+
+impl Files {
+    fn write(&mut self, path: &str, text: &str) {
+        self.0.insert(path.into(), text.into());
+    }
+}
+
+/// Test cache eviction.
+#[test]
+#[serial]
+fn test_evict() {
+    #[memoize]
+    fn null() -> u8 {
+        0
+    }
+
+    test!(miss: null(), 0);
+    test!(hit: null(), 0);
+    evict(2);
+    test!(hit: null(), 0);
+    evict(2);
+    evict(2);
+    test!(hit: null(), 0);
+    evict(2);
+    evict(2);
+    evict(2);
+    test!(miss: null(), 0);
+    test!(hit: null(), 0);
+    evict(0);
+    test!(miss: null(), 0);
+    test!(hit: null(), 0);
+}
+
+/// Test tracking a trait object.
+#[test]
+#[serial]
+fn test_tracked_trait() {
+    #[memoize]
+    fn traity(loader: Tracked<dyn Loader + '_>, path: &Path) -> Vec<u8> {
+        loader.load(path).unwrap()
+    }
+
+    fn wrapper(loader: &(dyn Loader), path: &Path) -> Vec<u8> {
+        traity(loader.track(), path)
+    }
+
+    let loader: &(dyn Loader) = &StaticLoader;
+    test!(miss: traity(loader.track(), Path::new("hi.rs")), [1, 2, 3]);
+    test!(hit: traity(loader.track(), Path::new("hi.rs")), [1, 2, 3]);
+    test!(miss: traity(loader.track(), Path::new("bye.rs")), [1, 2, 3]);
+    wrapper(loader, Path::new("hi.rs"));
+}
+
+#[track]
+trait Loader: Send + Sync {
+    fn load(&self, path: &Path) -> Result<Vec<u8>, String>;
+}
+
+struct StaticLoader;
+impl Loader for StaticLoader {
+    fn load(&self, _: &Path) -> Result<Vec<u8>, String> {
+        Ok(vec![1, 2, 3])
+    }
+}
+
+/// Test memoized methods.
+#[test]
+#[serial]
+fn test_memoized_methods() {
+    #[derive(Hash)]
+    struct Taker(String);
+
+    /// Has memoized methods.
+    impl Taker {
         #[memoize]
-        fn empty() -> String {
-            format!("The world is {}", "big")
-        }
-
-        #[memoize]
-        fn double(x: u32) -> u32 {
-            2 * x
-        }
-
-        #[memoize]
-        fn sum(a: u32, b: u32) -> u32 {
-            a + b
-        }
-
-        #[memoize]
-        fn fib(n: u32) -> u32 {
-            if n <= 2 {
-                1
-            } else {
-                fib(n - 1) + fib(n - 2)
-            }
-        }
-
-        #[memoize]
-        fn sum_iter(n: u32) -> u32 {
-            (0..n).sum()
-        }
-
-        test!(miss: empty(), "The world is big");
-        test!(hit: empty(), "The world is big");
-        test!(hit: empty(), "The world is big");
-
-        test!(miss: double(2), 4);
-        test!(miss: double(4), 8);
-        test!(hit: double(2), 4);
-
-        test!(miss: sum(2, 4), 6);
-        test!(miss: sum(2, 3), 5);
-        test!(hit: sum(2, 3), 5);
-        test!(miss: sum(4, 2), 6);
-
-        test!(miss: fib(5), 5);
-        test!(hit: fib(3), 2);
-        test!(miss: fib(8), 21);
-        test!(hit: fib(7), 13);
-
-        test!(miss: sum_iter(1000), 499500);
-        test!(hit: sum_iter(1000), 499500);
-    }
-
-    /// Test the calc language.
-    #[test]
-    #[serial]
-    fn test_calc() {
-        #[memoize]
-        fn evaluate(script: &str, files: Tracked<Files>) -> i32 {
-            script
-                .split('+')
-                .map(str::trim)
-                .map(|part| match part.strip_prefix("eval ") {
-                    Some(path) => evaluate(&files.read(path), files),
-                    None => part.parse::<i32>().unwrap(),
-                })
-                .sum()
-        }
-
-        let mut files = Files(HashMap::new());
-        files.write("alpha.calc", "2 + eval beta.calc");
-        files.write("beta.calc", "2 + 3");
-        files.write("gamma.calc", "8 + 3");
-        test!(miss: evaluate("eval alpha.calc", files.track()), 7);
-        test!(miss: evaluate("eval beta.calc", files.track()), 5);
-        files.write("gamma.calc", "42");
-        test!(hit: evaluate("eval alpha.calc", files.track()), 7);
-        files.write("beta.calc", "4 + eval gamma.calc");
-        test!(miss: evaluate("eval beta.calc", files.track()), 46);
-        test!(miss: evaluate("eval alpha.calc", files.track()), 48);
-        files.write("gamma.calc", "80");
-        test!(miss: evaluate("eval alpha.calc", files.track()), 86);
-    }
-
-    struct Files(HashMap<PathBuf, String>);
-
-    #[track]
-    impl Files {
-        fn read(&self, path: &str) -> String {
-            self.0.get(Path::new(path)).cloned().unwrap_or_default()
-        }
-    }
-
-    impl Files {
-        fn write(&mut self, path: &str, text: &str) {
-            self.0.insert(path.into(), text.into());
-        }
-    }
-
-    /// Test cache eviction.
-    #[test]
-    #[serial]
-    fn test_evict() {
-        #[memoize]
-        fn null() -> u8 {
-            0
-        }
-
-        test!(miss: null(), 0);
-        test!(hit: null(), 0);
-        evict(2);
-        test!(hit: null(), 0);
-        evict(2);
-        evict(2);
-        test!(hit: null(), 0);
-        evict(2);
-        evict(2);
-        evict(2);
-        test!(miss: null(), 0);
-        test!(hit: null(), 0);
-        evict(0);
-        test!(miss: null(), 0);
-        test!(hit: null(), 0);
-    }
-
-    /// Test tracking a trait object.
-    #[test]
-    #[serial]
-    fn test_tracked_trait() {
-        #[memoize]
-        fn traity(loader: Tracked<dyn Loader + '_>, path: &Path) -> Vec<u8> {
-            loader.load(path).unwrap()
-        }
-
-        fn wrapper(loader: &(dyn Loader), path: &Path) -> Vec<u8> {
-            traity(loader.track(), path)
-        }
-
-        let loader: &(dyn Loader) = &StaticLoader;
-        test!(miss: traity(loader.track(), Path::new("hi.rs")), [1, 2, 3]);
-        test!(hit: traity(loader.track(), Path::new("hi.rs")), [1, 2, 3]);
-        test!(miss: traity(loader.track(), Path::new("bye.rs")), [1, 2, 3]);
-        wrapper(loader, Path::new("hi.rs"));
-    }
-
-    #[track]
-    trait Loader: Send + Sync {
-        fn load(&self, path: &Path) -> Result<Vec<u8>, String>;
-    }
-
-    struct StaticLoader;
-    impl Loader for StaticLoader {
-        fn load(&self, _: &Path) -> Result<Vec<u8>, String> {
-            Ok(vec![1, 2, 3])
-        }
-    }
-
-    /// Test memoized methods.
-    #[test]
-    #[serial]
-    fn test_memoized_methods() {
-        #[derive(Hash)]
-        struct Taker(String);
-
-        /// Has memoized methods.
-        impl Taker {
-            #[memoize]
-            fn copy(&self) -> String {
-                self.0.clone()
-            }
-
-            #[memoize]
-            fn take(self) -> String {
-                self.0
-            }
-        }
-
-        test!(miss: Taker("Hello".into()).take(), "Hello");
-        test!(miss: Taker("Hello".into()).copy(), "Hello");
-        test!(miss: Taker("World".into()).take(), "World");
-        test!(hit: Taker("Hello".into()).take(), "Hello");
-    }
-
-    /// Test different kinds of arguments.
-    #[test]
-    #[serial]
-    fn test_kinds() {
-        #[memoize]
-        fn selfie(tester: Tracky) -> String {
-            tester.self_ref().into()
+        fn copy(&self) -> String {
+            self.0.clone()
         }
 
         #[memoize]
-        fn unconditional(tester: Tracky) -> &'static str {
-            if tester.by_value(Heavy("HEAVY".into())) > 10 {
-                "Long"
-            } else {
-                "Short"
-            }
+        fn take(self) -> String {
+            self.0
         }
-
-        let mut tester = Tester { data: "Hi".to_string() };
-
-        let tracky = tester.track();
-        test!(miss: selfie(tracky), "Hi");
-        test!(miss: unconditional(tracky), "Short");
-        test!(hit: unconditional(tracky), "Short");
-        test!(hit: selfie(tracky), "Hi");
-
-        tester.data.push('!');
-
-        let tracky = tester.track();
-        test!(miss: selfie(tracky), "Hi!");
-        test!(miss: unconditional(tracky), "Short");
-
-        tester.data.push_str(" Let's go.");
-
-        let tracky = tester.track();
-        test!(miss: unconditional(tracky), "Long");
     }
 
-    /// Test with type alias.
-    type Tracky<'a> = comemo::Tracked<'a, Tester>;
+    test!(miss: Taker("Hello".into()).take(), "Hello");
+    test!(miss: Taker("Hello".into()).copy(), "Hello");
+    test!(miss: Taker("World".into()).take(), "World");
+    test!(hit: Taker("Hello".into()).take(), "Hello");
+}
 
-    /// A struct with some data.
-    struct Tester {
-        data: String,
+/// Test different kinds of arguments.
+#[test]
+#[serial]
+fn test_kinds() {
+    #[memoize]
+    fn selfie(tester: Tracky) -> String {
+        tester.self_ref().into()
     }
 
-    /// Tests different kinds of arguments.
-    #[track]
-    impl Tester {
-        /// Return value can borrow from self.
-        #[allow(clippy::needless_lifetimes)]
-        fn self_ref<'a>(&'a self) -> &'a str {
+    #[memoize]
+    fn unconditional(tester: Tracky) -> &'static str {
+        if tester.by_value(Heavy("HEAVY".into())) > 10 {
+            "Long"
+        } else {
+            "Short"
+        }
+    }
+
+    let mut tester = Tester { data: "Hi".to_string() };
+
+    let tracky = tester.track();
+    test!(miss: selfie(tracky), "Hi");
+    test!(miss: unconditional(tracky), "Short");
+    test!(hit: unconditional(tracky), "Short");
+    test!(hit: selfie(tracky), "Hi");
+
+    tester.data.push('!');
+
+    let tracky = tester.track();
+    test!(miss: selfie(tracky), "Hi!");
+    test!(miss: unconditional(tracky), "Short");
+
+    tester.data.push_str(" Let's go.");
+
+    let tracky = tester.track();
+    test!(miss: unconditional(tracky), "Long");
+}
+
+/// Test with type alias.
+type Tracky<'a> = comemo::Tracked<'a, Tester>;
+
+/// A struct with some data.
+struct Tester {
+    data: String,
+}
+
+/// Tests different kinds of arguments.
+#[track]
+impl Tester {
+    /// Return value can borrow from self.
+    #[allow(clippy::needless_lifetimes)]
+    fn self_ref<'a>(&'a self) -> &'a str {
+        &self.data
+    }
+
+    /// Return value can borrow from argument.
+    fn arg_ref<'a>(&self, name: &'a str) -> &'a str {
+        name
+    }
+
+    /// Return value can borrow from both.
+    fn double_ref<'a>(&'a self, name: &'a str) -> &'a str {
+        if name.len() > self.data.len() {
+            name
+        } else {
             &self.data
         }
-
-        /// Return value can borrow from argument.
-        fn arg_ref<'a>(&self, name: &'a str) -> &'a str {
-            name
-        }
-
-        /// Return value can borrow from both.
-        fn double_ref<'a>(&'a self, name: &'a str) -> &'a str {
-            if name.len() > self.data.len() {
-                name
-            } else {
-                &self.data
-            }
-        }
-
-        /// Normal method with owned argument.
-        fn by_value(&self, heavy: Heavy) -> usize {
-            self.data.len() + heavy.0.len()
-        }
     }
 
-    /// Test empty type without methods.
-    struct Empty;
+    /// Normal method with owned argument.
+    fn by_value(&self, heavy: Heavy) -> usize {
+        self.data.len() + heavy.0.len()
+    }
+}
 
-    #[track]
-    impl Empty {}
+/// Test empty type without methods.
+struct Empty;
 
-    /// Test tracking a type with a lifetime.
-    #[test]
-    #[serial]
-    fn test_lifetime() {
-        #[comemo::memoize]
-        fn contains_hello(lifeful: Tracked<Lifeful>) -> bool {
-            lifeful.contains("hello")
-        }
+#[track]
+impl Empty {}
 
-        let lifeful = Lifeful("hey");
-        test!(miss: contains_hello(lifeful.track()), false);
-        test!(hit: contains_hello(lifeful.track()), false);
-
-        let lifeful = Lifeful("hello");
-        test!(miss: contains_hello(lifeful.track()), true);
-        test!(hit: contains_hello(lifeful.track()), true);
+/// Test tracking a type with a lifetime.
+#[test]
+#[serial]
+fn test_lifetime() {
+    #[comemo::memoize]
+    fn contains_hello(lifeful: Tracked<Lifeful>) -> bool {
+        lifeful.contains("hello")
     }
 
-    /// Test tracked with lifetime.
-    struct Lifeful<'a>(&'a str);
+    let lifeful = Lifeful("hey");
+    test!(miss: contains_hello(lifeful.track()), false);
+    test!(hit: contains_hello(lifeful.track()), false);
 
-    #[track]
-    impl<'a> Lifeful<'a> {
-        fn contains(&self, text: &str) -> bool {
-            self.0 == text
-        }
+    let lifeful = Lifeful("hello");
+    test!(miss: contains_hello(lifeful.track()), true);
+    test!(hit: contains_hello(lifeful.track()), true);
+}
+
+/// Test tracked with lifetime.
+struct Lifeful<'a>(&'a str);
+
+#[track]
+impl<'a> Lifeful<'a> {
+    fn contains(&self, text: &str) -> bool {
+        self.0 == text
+    }
+}
+
+/// Test tracking a type with a chain of tracked values.
+#[test]
+#[serial]
+fn test_chain() {
+    #[comemo::memoize]
+    fn process(chain: Tracked<Chain>, value: u32) -> bool {
+        chain.contains(value)
     }
 
-    /// Test tracking a type with a chain of tracked values.
-    #[test]
-    #[serial]
-    fn test_chain() {
-        #[comemo::memoize]
-        fn process(chain: Tracked<Chain>, value: u32) -> bool {
-            chain.contains(value)
-        }
+    let chain1 = Chain::new(1);
+    let chain3 = Chain::new(3);
+    let chain12 = Chain::insert(chain1.track(), 2);
+    let chain123 = Chain::insert(chain12.track(), 3);
+    let chain124 = Chain::insert(chain12.track(), 4);
+    let chain1245 = Chain::insert(chain124.track(), 5);
 
-        let chain1 = Chain::new(1);
-        let chain3 = Chain::new(3);
-        let chain12 = Chain::insert(chain1.track(), 2);
-        let chain123 = Chain::insert(chain12.track(), 3);
-        let chain124 = Chain::insert(chain12.track(), 4);
-        let chain1245 = Chain::insert(chain124.track(), 5);
+    test!(miss: process(chain1.track(), 0), false);
+    test!(miss: process(chain1.track(), 1), true);
+    test!(miss: process(chain123.track(), 2), true);
+    test!(hit: process(chain124.track(), 2), true);
+    test!(hit: process(chain12.track(), 2), true);
+    test!(hit: process(chain1245.track(), 2), true);
+    test!(miss: process(chain1.track(), 2), false);
+    test!(hit: process(chain3.track(), 2), false);
+}
 
-        test!(miss: process(chain1.track(), 0), false);
-        test!(miss: process(chain1.track(), 1), true);
-        test!(miss: process(chain123.track(), 2), true);
-        test!(hit: process(chain124.track(), 2), true);
-        test!(hit: process(chain12.track(), 2), true);
-        test!(hit: process(chain1245.track(), 2), true);
-        test!(miss: process(chain1.track(), 2), false);
-        test!(hit: process(chain3.track(), 2), false);
+/// Test that `Tracked<T>` is covariant over `T`.
+#[test]
+#[serial]
+#[allow(unused, clippy::needless_lifetimes)]
+fn test_variance() {
+    fn foo<'a>(_: Tracked<'a, Chain<'a>>) {}
+    fn bar<'a>(chain: Tracked<'a, Chain<'static>>) {
+        foo(chain);
+    }
+}
+
+/// Test tracked with lifetime.
+struct Chain<'a> {
+    // Need to override the lifetime here so that a `Tracked` is covariant over
+    // `Chain`.
+    outer: Option<Tracked<'a, Self, <Chain<'static> as Validate>::Constraint>>,
+    value: u32,
+}
+
+impl<'a> Chain<'a> {
+    /// Create a new chain entry point.
+    fn new(value: u32) -> Self {
+        Self { outer: None, value }
     }
 
-    /// Test that `Tracked<T>` is covariant over `T`.
-    #[test]
-    #[serial]
-    #[allow(unused, clippy::needless_lifetimes)]
-    fn test_variance() {
-        fn foo<'a>(_: Tracked<'a, Chain<'a>>) {}
-        fn bar<'a>(chain: Tracked<'a, Chain<'static>>) {
-            foo(chain);
-        }
+    /// Insert a link into the chain.
+    fn insert(outer: Tracked<'a, Self>, value: u32) -> Self {
+        Chain { outer: Some(outer), value }
     }
+}
 
-    /// Test tracked with lifetime.
-    struct Chain<'a> {
-        // Need to override the lifetime here so that a `Tracked` is covariant over
-        // `Chain`.
-        outer: Option<Tracked<'a, Self, <Chain<'static> as Validate>::Constraint>>,
-        value: u32,
+#[track]
+impl<'a> Chain<'a> {
+    fn contains(&self, value: u32) -> bool {
+        self.value == value || self.outer.map_or(false, |outer| outer.contains(value))
     }
+}
 
-    impl<'a> Chain<'a> {
-        /// Create a new chain entry point.
-        fn new(value: u32) -> Self {
-            Self { outer: None, value }
-        }
-
-        /// Insert a link into the chain.
-        fn insert(outer: Tracked<'a, Self>, value: u32) -> Self {
-            Chain { outer: Some(outer), value }
-        }
-    }
-
-    #[track]
-    impl<'a> Chain<'a> {
-        fn contains(&self, value: u32) -> bool {
-            self.value == value || self.outer.map_or(false, |outer| outer.contains(value))
-        }
-    }
-
-    /// Test mutable tracking.
+/// Test mutable tracking.
     #[test]
     #[serial]
     #[rustfmt::skip]
@@ -388,7 +388,7 @@ mod tests {
             let c = sink.len_or_ten().to_string();
             sink.emit(&c);
         }
-    
+
         let mut emitter = Emitter(vec![]);
         test!(miss: dump(emitter.track_mut()), ());
         test!(miss: dump(emitter.track_mut()), ());
@@ -406,50 +406,49 @@ mod tests {
         ])
     }
 
-    /// A tracked type with a mutable and an immutable method.
-    #[derive(Clone)]
-    struct Emitter(Vec<String>);
+/// A tracked type with a mutable and an immutable method.
+#[derive(Clone)]
+struct Emitter(Vec<String>);
 
-    #[track]
-    impl Emitter {
-        fn emit(&mut self, msg: &str) {
-            self.0.push(msg.into());
-        }
-
-        fn len_or_ten(&self) -> usize {
-            self.0.len().min(10)
-        }
+#[track]
+impl Emitter {
+    fn emit(&mut self, msg: &str) {
+        self.0.push(msg.into());
     }
 
-    /// A non-copy struct that is passed by value to a tracked method.
-    #[derive(Clone, PartialEq, Hash)]
-    struct Heavy(String);
+    fn len_or_ten(&self) -> usize {
+        self.0.len().min(10)
+    }
+}
 
-    /// Test a tracked method that is impure.
-    #[test]
-    #[serial]
-    #[cfg(debug_assertions)]
-    #[should_panic(
-        expected = "comemo: found conflicting constraints. is this tracked function pure?"
-    )]
-    fn test_impure_tracked_method() {
-        #[comemo::memoize]
-        fn call(impure: Tracked<Impure>) -> u32 {
-            impure.impure();
-            impure.impure()
-        }
+/// A non-copy struct that is passed by value to a tracked method.
+#[derive(Clone, PartialEq, Hash)]
+struct Heavy(String);
 
-        call(Impure.track());
+/// Test a tracked method that is impure.
+#[test]
+#[serial]
+#[cfg(debug_assertions)]
+#[should_panic(
+    expected = "comemo: found conflicting constraints. is this tracked function pure?"
+)]
+fn test_impure_tracked_method() {
+    #[comemo::memoize]
+    fn call(impure: Tracked<Impure>) -> u32 {
+        impure.impure();
+        impure.impure()
     }
 
-    struct Impure;
+    call(Impure.track());
+}
 
-    #[track]
-    impl Impure {
-        fn impure(&self) -> u32 {
-            use std::sync::atomic::{AtomicU32, Ordering};
-            static VAL: AtomicU32 = AtomicU32::new(0);
-            VAL.fetch_add(1, Ordering::SeqCst)
-        }
+struct Impure;
+
+#[track]
+impl Impure {
+    fn impure(&self) -> u32 {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static VAL: AtomicU32 = AtomicU32::new(0);
+        VAL.fetch_add(1, Ordering::SeqCst)
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -76,12 +76,12 @@ fn test_basic() {
 #[serial]
 fn test_calc() {
     #[memoize]
-    fn evaluate(script: &str, files: &Tracked<Files>) -> i32 {
+    fn evaluate(script: &str, files: Tracked<Files>) -> i32 {
         script
             .split('+')
             .map(str::trim)
             .map(|part| match part.strip_prefix("eval ") {
-                Some(path) => evaluate(&files.read(path), &files),
+                Some(path) => evaluate(&files.read(path), files),
                 None => part.parse::<i32>().unwrap(),
             })
             .sum()
@@ -91,15 +91,15 @@ fn test_calc() {
     files.write("alpha.calc", "2 + eval beta.calc");
     files.write("beta.calc", "2 + 3");
     files.write("gamma.calc", "8 + 3");
-    test!(miss: evaluate("eval alpha.calc", &files.track()), 7);
-    test!(miss: evaluate("eval beta.calc", &files.track()), 5);
+    test!(miss: evaluate("eval alpha.calc", files.track()), 7);
+    test!(miss: evaluate("eval beta.calc", files.track()), 5);
     files.write("gamma.calc", "42");
-    test!(hit: evaluate("eval alpha.calc", &files.track()), 7);
+    test!(hit: evaluate("eval alpha.calc", files.track()), 7);
     files.write("beta.calc", "4 + eval gamma.calc");
-    test!(miss: evaluate("eval beta.calc", &files.track()), 46);
-    test!(miss: evaluate("eval alpha.calc", &files.track()), 48);
+    test!(miss: evaluate("eval beta.calc", files.track()), 46);
+    test!(miss: evaluate("eval alpha.calc", files.track()), 48);
     files.write("gamma.calc", "80");
-    test!(miss: evaluate("eval alpha.calc", &files.track()), 86);
+    test!(miss: evaluate("eval alpha.calc", files.track()), 86);
 }
 
 struct Files(HashMap<PathBuf, String>);


### PR DESCRIPTION
This PR introduces the following changes:

- Now works in a multithreaded contexts: all parallel calls to memoized functions race to completion, could add a system for waiting on already "launched" functions using a `OnceCell`
- Now works with local caches, that means that all functions now have a static cache defined locally, this involves the following advantages:
  - Caches are smaller, therefore lookups *may* be faster
  - Caches are typed: removes the `Box<dyn Any>` that was used before
  - We don't need to hash the `TypeId` when doing cache lookups
- Added `ImmutableConstraint` which involves the following changes:
  - In the event that a `#[track]`ed struct only has immutable methods, we can just use a `HashMap` of visited functions which is faster for lookups, also has some niceties to save some work during validation, etc.
- Optimized `Constraint`:
  - Now uses a `Vec<Call<T>>` for storing function calls in order
  - Now uses `HashMap<u128, usize>` for storing immutable calls since the last mutable call, this allows much faster lookups in the event of a mixed mutable-immutables tracked struct.
- Made tests run sequentially, otherwise some test would randomly fail due to `test_evict` running in parallel and evicting the cache of other tests
- `last_was_hit` is now behind a feature flag: we don't need it in actual applications and it saves some time, it's thread-local
- This purposefully does not use `DashMap` to avoid a [bug in Safari](https://bugs.webkit.org/show_bug.cgi?id=265581). The problem with making two implementations is that `Constraint`, `ImmutableConstraint`, and `ACCELERATOR` would all change leading to large code duplication, but if @laurmaedje wants it implemented this may, I think it would show better performance on "native" targets.
- Eviction is now done on a per-cache level and caches are registered during lazy evaluation of the caches.
- Caches now use a `hashbrown::HashMap` as they can be slightly faster and we already have this dependency in Typst from `indexmap`.
- **Regression**: memoized functions can no longer be generic, I think this could be alleviated using a special `memoized_generic` that still uses a `Box<dyn Any>` under the hood. However, generic memoized functions are not part of Typst and therefore I am unsure whether the burden of maintaining two implementations is worth it.
- **Regression**: when doing memoized and tracked functions, you can no longer refer to the current type as `Self`, it has to be the full name of the type. This is very minor and has little to no impact on functionality.
- IDs are now atomic, they are using the `SeqCst` ordering, but I wonder whether they could be made with a less restrictive ordering but I am not knowledgeable enough for this.

Overall, and in spite of locking, these changes bring gigantic performance gains in incremental in Typst, in some cases doubling incremental performance.