### PR TITLE
Local memoization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ mod input;
 mod prehashed;
 mod track;
 
-pub use crate::cache::evict;
+pub use crate::cache::{evict, local_evict};
 pub use crate::prehashed::Prehashed;
 pub use crate::track::{Track, Tracked, TrackedMut, Validate};
 pub use comemo_macros::{memoize, track};
@@ -99,7 +99,9 @@ pub use comemo_macros::{memoize, track};
 pub mod internal {
     pub use parking_lot::RwLock;
 
-    pub use crate::cache::{memoized, register_evictor, Cache, CacheData};
+    pub use crate::cache::{
+        memoized, register_evictor, register_local_evictor, Cache, CacheData,
+    };
     pub use crate::constraint::{hash, Call, ImmutableConstraint, MutableConstraint};
     pub use crate::input::{assert_hashable_or_trackable, Args, Input};
     pub use crate::track::{to_parts_mut_mut, to_parts_mut_ref, to_parts_ref, Surfaces};


### PR DESCRIPTION
Also allows local memoization of function results with `#[comemo::memoize(local)]` and a special `evict_local` function. This is specifically for interfacing with typst-preview.

The only quirks is that for passing tracked and borrowed values into a locally memoized function you need to manually annotate the lifetime with `'local` specifically!
```rs
#[comemo::memoize(local)]
fn dump<'local>(mut sink: TrackedMut<'local, Emitter>) {
    sink.emit("a");
    sink.emit("b");
    let c = sink.len_or_ten().to_string();
    sink.emit(&c);
}
```

I also added a test that checks local eviction, tracked in local contexts, and simple local functions.
