### PR TITLE
MVP serialize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,11 @@ default = []
 testing = []
 
 [dependencies]
+bincode = "1.3.3"
 comemo-macros = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
+serde = { version = "1.0.197", features = ["serde_derive"] }
 siphasher = { workspace = true }
 
 [dev-dependencies]

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -77,9 +77,16 @@ use syn::{parse_quote, Error, Result};
 /// ```
 ///
 #[proc_macro_attribute]
-pub fn memoize(_: BoundaryStream, stream: BoundaryStream) -> BoundaryStream {
+pub fn memoize(attr: BoundaryStream, stream: BoundaryStream) -> BoundaryStream {
     let func = syn::parse_macro_input!(stream as syn::Item);
-    memoize::expand(&func)
+    let serializable = match attr.to_string().as_str() {
+        "serialize" => true,
+        "" => false,
+        invalid => {
+            panic!("invalid attribute: {invalid}\nvalid attributes is `serialize`")
+        }
+    };
+    memoize::expand(&func, serializable)
         .unwrap_or_else(|err| err.to_compile_error())
         .into()
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -61,7 +61,7 @@ use syn::{parse_quote, Error, Result};
 /// arguments.
 ///
 /// # Example
-/// ```
+/// ```ignore
 /// /// Evaluate a `.calc` script.
 /// #[comemo::memoize]
 /// fn evaluate(script: &str, files: comemo::Tracked<Files>) -> i32 {
@@ -140,7 +140,7 @@ pub fn memoize(attr: BoundaryStream, stream: BoundaryStream) -> BoundaryStream {
 /// - They cannot use destructuring patterns in their arguments.
 ///
 /// # Example
-/// ```
+/// ```ignore
 /// /// File storage.
 /// struct Files(HashMap<PathBuf, String>);
 ///

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
 use siphasher::sip128::{Hasher128, SipHasher13};
 
 use crate::accelerate;
@@ -115,8 +116,13 @@ impl<C: 'static, Out: 'static> Cache<C, Out> {
     pub fn evict(&self, max_age: usize) {
         self.0.write().evict(max_age)
     }
+    #[doc(hidden)]
+    pub fn inner(&self) -> &Lazy<RwLock<CacheData<C, Out>>> {
+        &self.0
+    }
 }
 
+#[derive(Serialize, Deserialize)]
 /// The internal data for a cache.
 pub struct CacheData<C, Out> {
     /// Maps from hashes to memoized results.
@@ -166,6 +172,7 @@ impl<C, Out> Default for CacheData<C, Out> {
     }
 }
 
+#[derive(Serialize, Deserialize)]
 /// A memoized result.
 struct CacheEntry<C, Out> {
     /// The memoized function's constraint.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ pub use crate::cache::evict;
 pub use crate::prehashed::Prehashed;
 pub use crate::track::{Track, Tracked, TrackedMut, Validate};
 pub use comemo_macros::{memoize, track};
-pub use serialization::{serialize,deserialize};
+pub use serialization::{deserialize, serialize};
 
 /// These are implementation details. Do not rely on them!
 #[doc(hidden)]
@@ -104,7 +104,9 @@ pub mod internal {
     pub use crate::cache::{memoized, register_evictor, Cache, CacheData};
     pub use crate::constraint::{hash, Call, ImmutableConstraint, MutableConstraint};
     pub use crate::input::{assert_hashable_or_trackable, Args, Input};
-    pub use crate::serialization::{bincode, register_loader, register_serializer};
+    pub use crate::serialization::{
+        bincode, once_cell, register_loader, register_serializer,
+    };
     pub use crate::track::{to_parts_mut_mut, to_parts_mut_ref, to_parts_ref, Surfaces};
 
     #[cfg(feature = "testing")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ mod cache;
 mod constraint;
 mod input;
 mod prehashed;
+mod serialization;
 mod track;
 
 pub use crate::cache::evict;
@@ -102,6 +103,7 @@ pub mod internal {
     pub use crate::cache::{memoized, register_evictor, Cache, CacheData};
     pub use crate::constraint::{hash, Call, ImmutableConstraint, MutableConstraint};
     pub use crate::input::{assert_hashable_or_trackable, Args, Input};
+    pub use crate::serialization::{bincode, register_loader, register_serializer};
     pub use crate::track::{to_parts_mut_mut, to_parts_mut_ref, to_parts_ref, Surfaces};
 
     #[cfg(feature = "testing")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@ pub use crate::cache::evict;
 pub use crate::prehashed::Prehashed;
 pub use crate::track::{Track, Tracked, TrackedMut, Validate};
 pub use comemo_macros::{memoize, track};
+pub use serialization::{serialize,deserialize};
 
 /// These are implementation details. Do not rely on them!
 #[doc(hidden)]

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,31 +1,45 @@
-use std::{collections::HashMap, ops::Deref};
+pub use {bincode, once_cell};
 
-pub use bincode;
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
+use std::{collections::HashMap, ops::Deref};
 
-static SERIALIZERS: RwLock<Vec<fn() -> (String, Vec<u8>)>> = RwLock::new(vec![]);
-static LOADERS: RwLock<Lazy<HashMap<String, fn(&[u8])>>> =
+static SERIALIZERS: RwLock<Vec<fn() -> (u128, Vec<u8>)>> = RwLock::new(vec![]);
+static LOADERS: RwLock<Lazy<HashMap<u128, fn(&[u8])>>> =
     RwLock::new(Lazy::new(|| HashMap::new()));
 
-pub fn register_serializer(serializer: fn() -> (String, Vec<u8>)) {
+pub fn register_serializer(serializer: fn() -> (u128, Vec<u8>)) {
     SERIALIZERS.write().push(serializer)
 }
 
-pub fn register_loader(function_path: String, loader: fn(&[u8])) {
-    let conflict = LOADERS.write().insert(function_path, loader);
+pub fn register_loader(unique_id: u128, loader: fn(&[u8])) {
+    let conflict = LOADERS.write().insert(unique_id, loader);
     debug_assert!(conflict.is_none())
 }
 
-pub fn serialize() -> HashMap<String, Vec<u8>> {
-    SERIALIZERS.read().deref().iter().map(|f| f()).collect()
+/// returns a blob of binary data that you may load with [comemo::serialization::deserialize](deserialize).
+pub fn serialize() -> bincode::Result<Vec<u8>> {
+    bincode::serialize(
+        &SERIALIZERS
+            .read()
+            .deref()
+            .iter()
+            .map(|f| f())
+            .collect::<HashMap<u128, Vec<u8>>>(),
+    )
 }
 
-pub fn deserialize(data: HashMap<String, Vec<u8>>) {
+/// Errors if data is invalid, in which case the function simply returns without filling the caches.
+pub fn deserialize(data: Vec<u8>) -> Result<(), ()> {
+    let Ok(data) = bincode::deserialize::<HashMap<u128, Vec<u8>>>(&data) else {
+        return Err(());
+    };
+
     for (function_name, load_function) in LOADERS.read().deref().iter() {
         let Some(data) = data.get(function_name) else {
             continue;
         };
         load_function(data)
     }
+    Ok(())
 }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,0 +1,31 @@
+use std::{collections::HashMap, ops::Deref};
+
+pub use bincode;
+use once_cell::sync::Lazy;
+use parking_lot::RwLock;
+
+static SERIALIZERS: RwLock<Vec<fn() -> (String, Vec<u8>)>> = RwLock::new(vec![]);
+static LOADERS: RwLock<Lazy<HashMap<String, fn(&[u8])>>> =
+    RwLock::new(Lazy::new(|| HashMap::new()));
+
+pub fn register_serializer(serializer: fn() -> (String, Vec<u8>)) {
+    SERIALIZERS.write().push(serializer)
+}
+
+pub fn register_loader(function_path: String, loader: fn(&[u8])) {
+    let conflict = LOADERS.write().insert(function_path, loader);
+    debug_assert!(conflict.is_none())
+}
+
+pub fn serialize() -> HashMap<String, Vec<u8>> {
+    SERIALIZERS.read().deref().iter().map(|f| f()).collect()
+}
+
+pub fn deserialize(data: HashMap<String, Vec<u8>>) {
+    for (function_name, load_function) in LOADERS.read().deref().iter() {
+        let Some(data) = data.get(function_name) else {
+            continue;
+        };
+        load_function(data)
+    }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -456,18 +456,29 @@ impl Impure {
 
 #[test]
 #[serial]
-fn feature_store() {
+fn feature_store_all() {
     #[memoize(serialize)]
     fn empty() -> String {
         format!("The world is {}", "big")
     }
 
-    test!(miss: empty(),  "The world is big");
+    #[memoize(serialize)]
+    fn sum(a: i32, b: i32) -> i32 {
+        a + b
+    }
 
+    test!(miss: empty(),  "The world is big");
     test!(hit: empty(),  "The world is big");
-    let data = comemo::serialize();
-    dbg!(data.keys().collect::<Vec<_>>());
+
+    test!(miss: sum(1, 2),  3);
+    test!(hit: sum(1, 2),  3);
+
+    let data = comemo::serialize().unwrap();
     comemo::evict(0);
-    comemo::deserialize(data);
+    test!(miss: empty(),  "The world is big");
+    test!(miss: sum(1, 2),  3);
+
+    comemo::deserialize(data).unwrap();
     test!(hit: empty() , "The world is big");
+    test!(hit: sum(1, 2),  3);
 }


### PR DESCRIPTION
Howdy,
this is a very minimal implementation of which the design must be discussed: 

# How it works:
It registers serialization and de-serialization functions at declaration time and provides the serialization implementation.

You can retrieve a blob of data using `comemo::serialize()` and replace your current caches using `comemo::deserialize`

It needs a unique ID per function, currently it's a String using the module_path, file name and line but small performance could be gained by hashing it. (It's not using the name because syn current parsing provide a function item which is nameless)

# What I like:
- It works 
- It's not super complex

# What I like less:
- hard codes the serialization implementation (bincode), not necessarily a big deal but we should at least ensure it's the most efficient one
- exposes CacheData via inner() method which is a possible foot-gun for users (it's doc(hidden) so I feel like it's their responsibility) 
- To enable it per function, you need to add the `serialize` attribute, I think we should assume serialization and provide instead a no serialize option
- No way to measure how much data is useful, silently ignores incorrect data