### PR TITLE
Put macros behind feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,11 +35,12 @@ categories = { workspace = true }
 keywords = { workspace = true }
 
 [features]
-default = []
+default = ["macros"]
+macros = ["dep:comemo-macros"]
 testing = []
 
 [dependencies]
-comemo-macros = { workspace = true }
+comemo-macros = { workspace = true, optional = true }
 parking_lot = { workspace = true }
 siphasher = { workspace = true }
 
@@ -49,4 +50,4 @@ serial_test = { workspace = true }
 [[test]]
 name = "tests"
 path = "tests/tests.rs"
-required-features = ["testing"]
+required-features = ["macros", "testing"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,8 @@ mod track;
 pub use crate::cache::evict;
 pub use crate::hash::Prehashed;
 pub use crate::track::{Track, Tracked, TrackedMut, Validate};
+
+#[cfg(feature = "macros")]
 pub use comemo_macros::{memoize, track};
 
 /// These are implementation details. Do not rely on them!


### PR DESCRIPTION
Less dependencies when depending on `comemo` just for the hashing features.