### PR TITLE
Simplify lifetime setup

### DIFF
--- a/macros/src/memoize.rs
+++ b/macros/src/memoize.rs
@@ -134,7 +134,7 @@ fn process(function: &Function) -> Result<TokenStream> {
     // Construct the inner closure.
     let output = &function.output;
     let body = &function.item.block;
-    let closure = quote! { |#param_tuple| -> #output #body };
+    let closure = quote! { |::comemo::internal::Args(#param_tuple)| -> #output #body };
 
     // Adjust the function's body.
     let mut wrapped = function.item.clone();


### PR DESCRIPTION
The lifetimes I really want can't be expressed because `F: for<'a> FnOnce(In::WithLifetime<'a>) -> Out` implies `'a = 'static` due to borrow checker limitations (at least that's my understanding of it). But this solution is at least a bit simpler than the previous ones and actually in some ways simpler than the "true" lifetimes would be because we don't need the associated type on `Input`.