### PR TITLE
Use `fxhash` for hash maps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["incremental", "memoization", "tracked", "constraints"]
 
 [workspace.dependencies]
 comemo-macros = { version = "0.4.0", path = "macros" }
+fxhash = "0.2"
 once_cell = "1.18"
 parking_lot = "0.12"
 proc-macro2 = "1"
@@ -41,6 +42,7 @@ testing = []
 
 [dependencies]
 comemo-macros = { workspace = true, optional = true }
+fxhash = { workspace = true }
 parking_lot = { workspace = true }
 siphasher = { workspace = true }
 

--- a/src/accelerate.rs
+++ b/src/accelerate.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use fxhash::FxHashMap;
 use parking_lot::{MappedRwLockReadGuard, Mutex, RwLock, RwLockReadGuard};
 
 /// The global list of currently alive accelerators.
@@ -12,7 +12,7 @@ static ID: AtomicUsize = AtomicUsize::new(0);
 /// The type of each individual accelerator.
 ///
 /// Maps from call hashes to return hashes.
-type Accelerator = Mutex<HashMap<u128, u128>>;
+type Accelerator = Mutex<FxHashMap<u128, u128>>;
 
 /// Generate a new accelerator.
 pub fn id() -> usize {
@@ -58,6 +58,6 @@ pub fn get(id: usize) -> Option<MappedRwLockReadGuard<'static, Accelerator>> {
 fn resize(len: usize) {
     let mut pair = ACCELERATORS.write();
     if len > pair.1.len() {
-        pair.1.resize_with(len, || Mutex::new(HashMap::new()));
+        pair.1.resize_with(len, || Mutex::new(FxHashMap::default()));
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
 use std::sync::LazyLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use fxhash::FxHashMap;
 use parking_lot::RwLock;
 use siphasher::sip128::{Hasher128, SipHasher13};
 
@@ -132,7 +132,7 @@ impl<C: 'static, Out: 'static> Cache<C, Out> {
 /// The internal data for a cache.
 pub struct CacheData<C, Out> {
     /// Maps from hashes to memoized results.
-    entries: HashMap<u128, Vec<CacheEntry<C, Out>>>,
+    entries: FxHashMap<u128, Vec<CacheEntry<C, Out>>>,
 }
 
 impl<C, Out: 'static> CacheData<C, Out> {
@@ -174,7 +174,7 @@ impl<C, Out: 'static> CacheData<C, Out> {
 
 impl<C, Out> Default for CacheData<C, Out> {
     fn default() -> Self {
-        Self { entries: HashMap::new() }
+        Self { entries: FxHashMap::default() }
     }
 }
 

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::hash::Hash;
 
+use fxhash::FxHashMap;
 use parking_lot::RwLock;
 
 use crate::accelerate;
@@ -156,7 +156,7 @@ impl<T: Call> Default for MutableConstraint<T> {
 
 /// A map of calls.
 #[derive(Clone)]
-struct EntryMap<T: Call>(HashMap<u128, ConstraintEntry<T>>);
+struct EntryMap<T: Call>(FxHashMap<u128, ConstraintEntry<T>>);
 
 impl<T: Call> EntryMap<T> {
     /// Enter a constraint for a call to a function.
@@ -176,7 +176,7 @@ impl<T: Call> EntryMap<T> {
 
 impl<T: Call> Default for EntryMap<T> {
     fn default() -> Self {
-        Self(HashMap::new())
+        Self(FxHashMap::default())
     }
 }
 


### PR DESCRIPTION
In Typst, this leads to a total speedup in the range of 2-5% depending on the document, so it's quite a lot!